### PR TITLE
[WEB-69] Fix error when removing user from sign-up sheet

### DIFF
--- a/app/(authenticated)/calendar/[eventID]/schema.ts
+++ b/app/(authenticated)/calendar/[eventID]/schema.ts
@@ -16,7 +16,10 @@ export const CrewSchema = z.object({
   custom_position_name: z.string().optional(),
   ordering: z.number(),
   locked: z.boolean().default(false),
-  user_id: z.coerce.number().nullable().default(null),
+  user_id: z
+    .string()
+    .transform((v) => (v === "" ? null : v))
+    .pipe(z.coerce.number().nullable().default(null)),
 });
 
 export const SignupSheetSchema = z.object({


### PR DESCRIPTION
Zod was over-eager at converting the empty string into a number and would convert it to 0. Instead, explicitly convert the empty string to null.