### PR TITLE
[WEB-81] Split AdamRMS integration into separate permission

### DIFF
--- a/app/(authenticated)/calendar/[eventID]/EventActionsUI.tsx
+++ b/app/(authenticated)/calendar/[eventID]/EventActionsUI.tsx
@@ -25,6 +25,7 @@ import AdamRMSLogo from "../../../_assets/adamrms-logo.png";
 import { Button, Menu, Modal, Select, Text } from "@mantine/core";
 import { useModals } from "@mantine/modals";
 import { useRouter } from "next/navigation";
+import { PermissionGate } from "@/components/UserContext";
 
 function EditModal(props: { event: EventObjectType; close: () => void }) {
   return (
@@ -201,62 +202,64 @@ export function EventActionsUI(props: { event: EventObjectType }) {
           Cancel Event
         </Button>
       )}
-      <Menu shadow="md">
-        <Menu.Target>
-          <Button color="green" loading={isPending}>
-            <Image src={AdamRMSLogo} className="mr-1 h-4 w-4" alt="" />
-            {props.event.adam_rms_project_id !== null
-              ? "Kit List"
-              : "Create Kit List"}
-          </Button>
-        </Menu.Target>
-        <Menu.Dropdown>
-          {props.event.adam_rms_project_id === null ? (
-            <>
-              <Menu.Item
-                disabled={isPending}
-                onClick={() =>
-                  startTransition(async () => {
-                    await createAdamRMSProject(props.event.event_id);
-                  })
-                }
-              >
-                New AdamRMS Project
-              </Menu.Item>
-              <Menu.Item
-                disabled={isPending}
-                onClick={() =>
-                  startTransition(async () => {
-                    await doLink();
-                  })
-                }
-              >
-                Link Existing Project
-              </Menu.Item>
-            </>
-          ) : (
-            <>
-              <Menu.Item
-                component="a"
-                href={`https://dash.adam-rms.com/project/?id=${props.event.adam_rms_project_id}`}
-                target="_blank"
-              >
-                View AdamRMS Project
-              </Menu.Item>
-              <Menu.Item
-                disabled={isPending}
-                onClick={() =>
-                  startTransition(async () => {
-                    await unlinkAdamRMS(props.event.event_id);
-                  })
-                }
-              >
-                Unlink Project
-              </Menu.Item>
-            </>
-          )}
-        </Menu.Dropdown>
-      </Menu>
+      <PermissionGate required={["CalendarIntegration.Admin"]}>
+        <Menu shadow="md">
+          <Menu.Target>
+            <Button color="green" loading={isPending}>
+              <Image src={AdamRMSLogo} className="mr-1 h-4 w-4" alt="" />
+              {props.event.adam_rms_project_id !== null
+                ? "Kit List"
+                : "Create Kit List"}
+            </Button>
+          </Menu.Target>
+          <Menu.Dropdown>
+            {props.event.adam_rms_project_id === null ? (
+              <>
+                <Menu.Item
+                  disabled={isPending}
+                  onClick={() =>
+                    startTransition(async () => {
+                      await createAdamRMSProject(props.event.event_id);
+                    })
+                  }
+                >
+                  New AdamRMS Project
+                </Menu.Item>
+                <Menu.Item
+                  disabled={isPending}
+                  onClick={() =>
+                    startTransition(async () => {
+                      await doLink();
+                    })
+                  }
+                >
+                  Link Existing Project
+                </Menu.Item>
+              </>
+            ) : (
+              <>
+                <Menu.Item
+                  component="a"
+                  href={`https://dash.adam-rms.com/project/?id=${props.event.adam_rms_project_id}`}
+                  target="_blank"
+                >
+                  View AdamRMS Project
+                </Menu.Item>
+                <Menu.Item
+                  disabled={isPending}
+                  onClick={() =>
+                    startTransition(async () => {
+                      await unlinkAdamRMS(props.event.event_id);
+                    })
+                  }
+                >
+                  Unlink Project
+                </Menu.Item>
+              </>
+            )}
+          </Menu.Dropdown>
+        </Menu>
+      </PermissionGate>
       <Button onClick={() => setEditOpen(true)} className="block">
         Edit Event
       </Button>

--- a/app/(authenticated)/calendar/new/page.tsx
+++ b/app/(authenticated)/calendar/new/page.tsx
@@ -8,8 +8,9 @@ import {
   creatableEventTypes,
 } from "@/features/calendar/permissions";
 import * as Calendar from "@/features/calendar/events";
-import { Forbidden, Permission } from "@/lib/auth/common";
+import { Permission } from "@/lib/auth/permissions";
 import { revalidatePath } from "next/cache";
+import { Forbidden } from "@/lib/auth/errors";
 
 async function createEvent(
   data: unknown,

--- a/app/(authenticated)/error.tsx
+++ b/app/(authenticated)/error.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { isNotLoggedIn } from "@/lib/auth/common";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect } from "react";
+import { isNotLoggedIn } from "@/lib/auth/errors";
 
 export default function Error({
   error,

--- a/components/UserContext.tsx
+++ b/components/UserContext.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { createContext, useContext, useEffect, useMemo } from "react";
-import { Permission } from "@/lib/auth/common";
+import { Permission } from "@/lib/auth/permissions";
 import { UserType } from "@/lib/auth/server";
 import * as Sentry from "@sentry/nextjs";
 

--- a/features/calendar/permissions.ts
+++ b/features/calendar/permissions.ts
@@ -1,5 +1,5 @@
 import { EventType } from "@/features/calendar/types";
-import { Permission } from "@/lib/auth/common";
+import { Permission } from "@/lib/auth/permissions";
 import { UserType } from "@/lib/auth/server";
 import { Event } from "@prisma/client";
 import { SignUpSheetType } from "@/features/calendar/signup_sheets";

--- a/lib/auth/errors.ts
+++ b/lib/auth/errors.ts
@@ -1,4 +1,4 @@
-import { Permission } from "@/lib/auth/common";
+import type { Permission } from "@/lib/auth/permissions";
 
 const NOT_LOGGED_IN = "Not logged in";
 

--- a/lib/auth/google/index.ts
+++ b/lib/auth/google/index.ts
@@ -1,6 +1,5 @@
 import { prisma } from "@/lib/db";
 import { OAuth2Client } from "google-auth-library";
-import { NotLoggedIn } from "../common";
 
 const Google = new OAuth2Client();
 

--- a/lib/auth/permissions.ts
+++ b/lib/auth/permissions.ts
@@ -7,9 +7,6 @@ import { z } from "zod";
  * * PUBLIC - open to the world with no authentication
  * * SuperUser - can do anything (don't use this unless you know what you're doing)
  */
-// TODO: This is duplicated between here and the DB. In theory we could just use `string` as the type, but that
-//  loses auto-complete. We could also auto-generate it from the DB, but my preference would be to remove the
-//  DB permissions table entirely and have the codebase be the source of truth.
 export const PermissionEnum = z.enum([
   "PUBLIC",
   "MEMBER",
@@ -22,10 +19,9 @@ export const PermissionEnum = z.enum([
   "Calendar.Meeting.Creator",
   "Calendar.Social.Admin",
   "Calendar.Social.Creator",
+  "CalendarIntegration.Admin",
   "ManageMembers.Members.List",
   "ManageMembers.Members.Admin",
   "ManageMembers.Admin",
 ]);
 export type Permission = z.infer<typeof PermissionEnum>;
-
-export * from "./errors";

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -1,13 +1,12 @@
 import "server-only";
 import { prisma } from "@/lib/db";
 import { Forbidden, NotLoggedIn } from "./errors";
-import { Permission, PermissionEnum } from "./common";
+import { Permission } from "./permissions";
 import { User } from "@prisma/client";
 import { NextRequest } from "next/server";
 import { findOrCreateUserFromGoogleToken } from "./google";
 import { redirect } from "next/navigation";
 import { z } from "zod";
-import { _UserModel } from "../db/types";
 import { decode, encode } from "../sessionSecrets";
 
 export type UserType = User & {


### PR DESCRIPTION
Add a new permission, `CalendarIntegration.Admin`, which gates the AdamRMS integration, so that we can hide it from people who don't need to see it - as @itscfox put it, avoids the _"what does this button do?" "oh don't worry about it"_ conversation with new producers.

In terms of naming I didn't want to do something like `Calendar.Integration` or similar because that would suggests that `Calendar.Admin` is sufficient for that, which we don't want (that's the permission that the producer role has). I could have created an extra `Calendar.Manager` role, but that'd risk confusion between it and `Calendar.Admin`.

Many of the removed lines are dead code from an earlier merge gone wrong, and splitting `auth/common.ts` into `auth/permissions.ts` and `auth/errors.ts` for clarity.