### PR TITLE
[WEB-64] [DB] Exclude custom crew positions from selection initially

### DIFF
--- a/app/(authenticated)/calendar/[eventID]/page.tsx
+++ b/app/(authenticated)/calendar/[eventID]/page.tsx
@@ -12,7 +12,7 @@ import { EventObjectType, getEvent } from "@/features/calendar/events";
 import {
   canManage,
   canManageAnySignupSheet,
-  getAllCrewPositions,
+  getAllNonCustomCrewPositions,
 } from "@/features/calendar";
 import {
   CrewPositionsProvider,
@@ -87,11 +87,10 @@ async function ShowView({
   me: UserType;
 }) {
   if (canManageAnySignupSheet(event, me)) {
-    // TODO(WEB-40): this pre-loads quite a bit of information (~56k gzipped, 4MB uncompressed)
-    //  that we don't actually need until you go to edit a sheet.
+    // TODO(WEB-40): this pre-loads quite a bit of information that we don't actually need until you go to edit a sheet.
     //  Would be better to either load it on-demand dynamically, or move the edit view to a sub-page.
     const [positions, members] = await Promise.all([
-      getAllCrewPositions(),
+      getAllNonCustomCrewPositions(),
       getAllUsers(),
     ]);
     return (

--- a/features/calendar/crew_positions.ts
+++ b/features/calendar/crew_positions.ts
@@ -9,10 +9,13 @@ export interface CrewPositionType {
   full_description: string;
 }
 
-export function getAllCrewPositions(): Promise<CrewPositionType[]> {
+export function getAllNonCustomCrewPositions(): Promise<CrewPositionType[]> {
   return prisma.position.findMany({
     orderBy: {
       position_id: "asc",
     },
+    where: {
+      is_custom: false,
+    }
   });
 }

--- a/features/calendar/signup_sheets.ts
+++ b/features/calendar/signup_sheets.ts
@@ -107,6 +107,7 @@ async function ensurePositionsForCrews(crews: CrewCreateUpdateInput[]) {
         data: {
           name,
           full_description: "",
+          is_custom: true,
         },
       }),
     ),

--- a/lib/db/migrations/20231005214619_add_is_custom_to_positions/migration.sql
+++ b/lib/db/migrations/20231005214619_add_is_custom_to_positions/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "positions" ADD COLUMN     "is_custom" BOOLEAN NOT NULL DEFAULT false;

--- a/lib/db/schema.prisma
+++ b/lib/db/schema.prisma
@@ -146,6 +146,7 @@ model Position {
   brief_description String  @default("")
   full_description  String
   crews             Crew[]
+  is_custom         Boolean @default(false)
 
   @@map("positions")
 }

--- a/lib/db/types/position.ts
+++ b/lib/db/types/position.ts
@@ -8,6 +8,7 @@ export const _PositionModel = z.object({
   admin: z.boolean(),
   brief_description: z.string(),
   full_description: z.string(),
+  is_custom: z.boolean(),
 })
 
 export interface CompletePosition extends z.infer<typeof _PositionModel> {


### PR DESCRIPTION
Adds a new `is_custom` column to `positions`, which `Calendar.ensurePositionsForCrews()` sets to true by default, which then gets excluded from the dropdown. No way to make a position non-custom yet - that's WEB-89.

Fixes WEB-64.
Contributes to WEB-89, WEB-88.