### PR TITLE
[WEB-109] Deduplicate custom crew position names

### DIFF
--- a/features/calendar/signup_sheets.ts
+++ b/features/calendar/signup_sheets.ts
@@ -98,11 +98,14 @@ interface CrewCreateUpdateInput {
  * it with the position ID.
  */
 async function ensurePositionsForCrews(crews: CrewCreateUpdateInput[]) {
-  const newPosNames = crews
-    .filter((x) => x.custom_position_name)
-    .map((x) => x.custom_position_name!);
+  // Ensure we only create one new position even if it's given multiple times
+  const newPosNames = new Set(
+    crews
+      .filter((x) => x.custom_position_name)
+      .map((x) => x.custom_position_name!),
+  );
   const newPositions = await prisma.$transaction(
-    newPosNames.map((name) =>
+    Array.from(newPosNames).map((name) =>
       prisma.position.create({
         data: {
           name,


### PR DESCRIPTION
Previously, if the same crew position was specified multiple times, we would create multiple new positions. Now we only create one for each unique name.