### PR TITLE
[WEB-111] Grey out events that have ended

### DIFF
--- a/components/YSTVCalendar.tsx
+++ b/components/YSTVCalendar.tsx
@@ -254,12 +254,14 @@ export default function YSTVCalendar({
         }}
         dayCellContent={
           isMobileView
-            ? (day) =>
-                day.date.toLocaleDateString(undefined, {
+            ? (day) => {
+                if (day.view.type == "timeGridDay") return;
+                return day.date.toLocaleDateString(undefined, {
                   weekday: "short",
                   day: "2-digit",
                   month: "short",
-                })
+                });
+              }
             : undefined
         }
         viewClassNames={
@@ -320,7 +322,7 @@ export default function YSTVCalendar({
             eventObject.className = "ystv-calendar-strike-through";
           }
           if (evt.end_date < currentDate) {
-            eventObject.className += " opacity-50"
+            eventObject.className += " opacity-50";
           }
           return eventObject;
         })}


### PR DESCRIPTION
Set opacity of past events to 50% if the end time is earlier than the current time.