### PR TITLE
[WEB-61] Crew sheet duplication

### DIFF
--- a/app/(authenticated)/calendar/[eventID]/AddEditSignUpSheetForm.tsx
+++ b/app/(authenticated)/calendar/[eventID]/AddEditSignUpSheetForm.tsx
@@ -117,6 +117,12 @@ function CrewMemberField(props: { parentName: string }) {
 }
 
 export function AddEditSignUpSheetForm(props: {
+  // NB: this form is used in three cases:
+  // - creating a brand new sign-up sheet
+  // - cloning an existing one
+  // - editing an existing one
+  // In the first case there'll be no initialValues.
+  mode: "create" | "clone" | "edit";
   action: (data: z.infer<typeof SignupSheetSchema>) => Promise<FormResponse>;
   initialValues?: Partial<z.infer<typeof SignupSheetSchema>>;
   onSuccess: () => void;
@@ -132,7 +138,12 @@ export function AddEditSignUpSheetForm(props: {
       submitLabel={props.submitLabel}
     >
       <h1 className={"mb-2 mt-0 text-4xl font-bold"}>
-        {props.initialValues ? "Edit" : "New"} List
+        {props.mode === "create"
+          ? "New"
+          : props.mode === "clone"
+          ? "Duplicate"
+          : "Edit"}{" "}
+        List
       </h1>
       <TextField
         name="title"


### PR DESCRIPTION
Allow duplicating crew sheets within the same event, keeping the same structure but clearing out the crew members. Also moves the "edit" and "delete" buttons into a dropdown.