### PR TITLE
Migrate slack_user_id to identities table

### DIFF
--- a/app/(authenticated)/calendar/[eventID]/actions.ts
+++ b/app/(authenticated)/calendar/[eventID]/actions.ts
@@ -95,19 +95,20 @@ export async function updateAttendeeStatus(
 
   if (isSlackEnabled) {
     if (status === "attending" || status === "maybe_attending") {
-      if (me.slack_user_id && evt.slack_channel_id) {
+      const slackUser = me.identities.find((i) => i.provider === "slack");
+      if (slackUser && evt.slack_channel_id) {
         const slackApp = await slackApiConnection();
 
         try {
           await slackApp.client.conversations.invite({
             channel: evt.slack_channel_id,
-            users: me.slack_user_id,
+            users: slackUser.provider_key,
           });
         } catch (e) {}
 
         await slackApp.client.chat.postEphemeral({
           channel: evt.slack_channel_id,
-          user: me.slack_user_id,
+          user: slackUser.provider_key,
           text: `You have been added to this channel as you expressed your interest in attending '${evt.name}'.`,
         });
       }

--- a/app/(authenticated)/calendar/[eventID]/page.tsx
+++ b/app/(authenticated)/calendar/[eventID]/page.tsx
@@ -149,7 +149,7 @@ async function SlackBanner(props: { event: EventObjectType }) {
     return null;
   }
   const me = await getCurrentUser();
-  if (me.slack_user_id) {
+  if (me.identities.some((x) => x.provider === "slack")) {
     return null;
   }
 

--- a/app/(authenticated)/calendar/[eventID]/signUpSheetActions.ts
+++ b/app/(authenticated)/calendar/[eventID]/signUpSheetActions.ts
@@ -156,19 +156,20 @@ export async function signUpToRole(sheetID: number, crewID: number) {
   }
 
   if (isSlackEnabled) {
-    if (me.slack_user_id && sheet.events.slack_channel_id) {
+    const slackUser = me.identities.find((i) => i.provider === "slack");
+    if (slackUser && sheet.events.slack_channel_id) {
       const slackApp = await slackApiConnection();
 
       try {
         await slackApp.client.conversations.invite({
           channel: sheet.events.slack_channel_id,
-          users: me.slack_user_id,
+          users: slackUser.provider_key,
         });
       } catch (e) {}
 
       await slackApp.client.chat.postEphemeral({
         channel: sheet.events.slack_channel_id,
-        user: me.slack_user_id,
+        user: slackUser.provider_key,
         text: `You have been added to this channel as you signed up for the role of '${sheet.crews.find(
           (crew_pos) => {
             if (crew_pos.crew_id == crewID) {

--- a/app/(authenticated)/user/[id]/page.tsx
+++ b/app/(authenticated)/user/[id]/page.tsx
@@ -38,6 +38,7 @@ export default async function UserPage({ params }: { params: { id: string } }) {
     user = People.SecureUserModel.parse(dbUser);
   }
   const prefs = People.preferenceDefaults(user.preferences);
+  const slackUser = user.identities.find((i) => i.provider === "slack");
   return (
     <div>
       <Card withBorder>
@@ -104,7 +105,7 @@ export default async function UserPage({ params }: { params: { id: string } }) {
       <Space h={"md"} />
       {isSlackEnabled && (
         <>
-          {!user.slack_user_id ? (
+          {!slackUser ? (
             <Card withBorder>
               <h2 className="mt-0">Link your account to Slack</h2>
               <Suspense>
@@ -125,7 +126,7 @@ export default async function UserPage({ params }: { params: { id: string } }) {
                   </>
                 }
               >
-                <SlackUserInfo slack_user_id={user.slack_user_id} />
+                <SlackUserInfo slack_user_id={slackUser.provider_key} />
               </Suspense>
             </Card>
           )}

--- a/features/calendar/check_with_tech.ts
+++ b/features/calendar/check_with_tech.ts
@@ -14,8 +14,9 @@ export async function postCheckWithTech(eventID: number, memo: string) {
     throw new Error("Event not found");
   }
   const me = await getCurrentUser();
-  const user = me.slack_user_id
-    ? `<@${me.slack_user_id}>`
+  const slackUser = me.identities.find((x) => x.provider === "slack");
+  const user = slackUser
+    ? `<@${slackUser.provider_key}>`
     : `${me.first_name} ${me.last_name}`;
 
   const lines = [
@@ -53,8 +54,9 @@ export async function postTechHelpRequest(eventID: number, memo: string) {
     throw new Error("Event not found");
   }
   const me = await getCurrentUser();
-  const user = me.slack_user_id
-    ? `<@${me.slack_user_id}>`
+  const slackUser = me.identities.find((x) => x.provider === "slack");
+  const user = slackUser
+    ? `<@${slackUser.provider_key}>`
     : `${me.first_name} ${me.last_name}`;
 
   const lines = [

--- a/lib/db/migrations/20240304123936_migrate_slack_user_id_to_identities/migration.sql
+++ b/lib/db/migrations/20240304123936_migrate_slack_user_id_to_identities/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `slack_user_id` on the `users` table. All the data in the column will be lost.
+
+*/
+
+INSERT INTO "identities" ("user_id", "provider", "provider_key")
+SELECT "user_id", 'slack', "slack_user_id" FROM "users" WHERE "slack_user_id" IS NOT NULL;
+
+-- AlterTable
+ALTER TABLE "users" DROP COLUMN "slack_user_id";

--- a/lib/db/migrations/20240304124127_identities_unique/migration.sql
+++ b/lib/db/migrations/20240304124127_identities_unique/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[user_id,provider]` on the table `identities` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "identities_user_id_provider_key" ON "identities"("user_id", "provider");

--- a/lib/db/schema.prisma
+++ b/lib/db/schema.prisma
@@ -69,7 +69,6 @@ model User {
   events_events_updated_byTousers Event[]      @relation("events_updated_byTousers")
   role_members                    RoleMember[]
   hosted_events                   Event[]      @relation("event_host_user")
-  slack_user_id                   String       @default("")
 
   /// [UserPreferences]
   preferences Json @default("{}")
@@ -85,6 +84,7 @@ model Identity {
   provider_key String
 
   @@unique([provider, provider_key])
+  @@unique([user_id, provider])
   @@map("identities")
 }
 

--- a/lib/db/types/user.ts
+++ b/lib/db/types/user.ts
@@ -15,7 +15,6 @@ export const _UserModel = z.object({
   last_name: z.string(),
   nickname: z.string(),
   avatar: z.string(),
-  slack_user_id: z.string(),
   /**
    * [UserPreferences]
    */


### PR DESCRIPTION
Remove the `slack_user_id` field from `users`, and instead allow a `slack` provider in the `identities` table. Partly future-proofing for if we introduce Slack login, partly just for tidiness.