### PR TITLE
Add an API endpoint for showing public events

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
           if (env.BRANCH_NAME != 'main') {
             imageNamePrefix = "${env.BRANCH_NAME}-"
           }
-          imageTag = "${imageNamePrefix}${env.BUILD_NUMBER}"
+          imageTag = "${imageNamePrefix.replace('/', '--')}${env.BUILD_NUMBER}"
         }
       }
     }

--- a/app/(authenticated)/calendar/new/form.tsx
+++ b/app/(authenticated)/calendar/new/form.tsx
@@ -47,7 +47,7 @@ export function CreateEventForm(props: {
       />
       <ConditionalField
         referencedFieldName="type"
-        condition={(t) => t !== "show"}
+        condition={(t) => !["show", "public"].includes(t as string)}
         childFieldName="host"
       >
         <SearchedMemberSelect name="host" label="Host" />

--- a/app/(authenticated)/calendar/new/form.tsx
+++ b/app/(authenticated)/calendar/new/form.tsx
@@ -47,7 +47,7 @@ export function CreateEventForm(props: {
       />
       <ConditionalField
         referencedFieldName="type"
-        condition={(t) => !(["show", "public"].includes(t as string))}
+        condition={(t) => !["show", "public"].includes(t as string)}
         childFieldName="host"
       >
         <SearchedMemberSelect name="host" label="Host" />

--- a/app/(authenticated)/calendar/new/form.tsx
+++ b/app/(authenticated)/calendar/new/form.tsx
@@ -47,7 +47,7 @@ export function CreateEventForm(props: {
       />
       <ConditionalField
         referencedFieldName="type"
-        condition={(t) => !["show", "public"].includes(t as string)}
+        condition={(t) => !(["show", "public"].includes(t as string))}
         childFieldName="host"
       >
         <SearchedMemberSelect name="host" label="Host" />

--- a/app/(authenticated)/calendar/page.tsx
+++ b/app/(authenticated)/calendar/page.tsx
@@ -98,8 +98,8 @@ export default async function CalendarPage({
     "Calendar.Meeting.Creator",
     "Calendar.Social.Admin",
     "Calendar.Social.Creator",
-    "Calendar.Show.Admin",
-    "Calendar.Social.Creator",
+    "Calendar.Public.Admin",
+    "Calendar.Public.Creator",
   ];
 
   return (

--- a/app/api/public/events/route.ts
+++ b/app/api/public/events/route.ts
@@ -1,0 +1,8 @@
+import { listPublicEvents } from "@/features/calendar";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest, res: NextResponse) {
+  const events = await listPublicEvents();
+
+  return NextResponse.json(events);
+}

--- a/app/api/public/events/route.ts
+++ b/app/api/public/events/route.ts
@@ -1,6 +1,8 @@
 import { listPublicEvents } from "@/features/calendar";
 import { NextRequest, NextResponse } from "next/server";
 
+export const dynamic = "force-dynamic";
+
 export async function GET(req: NextRequest, res: NextResponse) {
   const events = await listPublicEvents();
 

--- a/features/calendar/events.ts
+++ b/features/calendar/events.ts
@@ -314,6 +314,7 @@ export async function listPublicEvents() {
 
   const res = await prisma.event.findMany({
     where: {
+      event_type: "public",
       start_date: {
         gte: eventSearchDate,
       },

--- a/features/calendar/permissions.ts
+++ b/features/calendar/permissions.ts
@@ -16,7 +16,7 @@ export function adminEventTypes(userPermissions: Permission[]): EventType[] {
     userPermissions.includes("Calendar.Admin") ||
     userPermissions.includes("SuperUser")
   ) {
-    permittedEventTypes.push("show", "meeting", "social", "other");
+    permittedEventTypes.push("show", "meeting", "social", "public", "other");
   } else {
     if (userPermissions.includes("Calendar.Show.Admin")) {
       permittedEventTypes.push("show");
@@ -26,6 +26,9 @@ export function adminEventTypes(userPermissions: Permission[]): EventType[] {
     }
     if (userPermissions.includes("Calendar.Social.Admin")) {
       permittedEventTypes.push("social");
+    }
+    if (userPermissions.includes("Calendar.Public.Admin")) {
+      permittedEventTypes.push("public");
     }
   }
   return Array.from(new Set(permittedEventTypes));
@@ -47,6 +50,9 @@ export function creatableEventTypes(
   }
   if (userPermissions.includes("Calendar.Social.Creator")) {
     base.push("social");
+  }
+  if (userPermissions.includes("Calendar.Public.Creator")) {
+    base.push("public");
   }
   return Array.from(new Set(base));
 }

--- a/features/calendar/types.ts
+++ b/features/calendar/types.ts
@@ -1,4 +1,10 @@
-export const EventTypes = ["show", "meeting", "social", "other"] as const;
+export const EventTypes = [
+  "show",
+  "meeting",
+  "social",
+  "public",
+  "other",
+] as const;
 export type EventType = (typeof EventTypes)[number];
 
 export function hasRSVP(type: EventType): boolean {

--- a/lib/auth/permissions.ts
+++ b/lib/auth/permissions.ts
@@ -19,6 +19,8 @@ export const PermissionEnum = z.enum([
   "Calendar.Meeting.Creator",
   "Calendar.Social.Admin",
   "Calendar.Social.Creator",
+  "Calendar.Public.Admin",
+  "Calendar.Public.Creator",
   "CalendarIntegration.Admin",
   "ManageMembers.Members.List",
   "ManageMembers.Members.Admin",


### PR DESCRIPTION
`/api/public/events` returns future events with the type "public". These can then be pulled and used on the welcome site for example. This allows events on the welcome site to be easily edited via the calendar.