### PR TITLE
Fix setting of cookie domain to .hostname instead of .host

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -43,7 +43,7 @@ const envSchema = z.object({
   SENTRY_PROJECT_ID: z.string().optional(),
   COOKIE_DOMAIN: z
     .string()
-    .default(new URL(process.env.PUBLIC_URL ?? "localhost").host),
+    .default(new URL(process.env.PUBLIC_URL ?? "localhost").hostname),
 });
 
 export function validateEnv(


### PR DESCRIPTION
Fixes a bug in local versions of the site, in which .host includes the port in the cookie domain, and subsequently session cookies weren't being set, using .hostname fixes this