### PR TITLE
[INT-177] Remove username from user

### DIFF
--- a/app/(authenticated)/layout.tsx
+++ b/app/(authenticated)/layout.tsx
@@ -25,7 +25,6 @@ export default async function AuthenticatedLayout({
 
   Sentry.setUser({
     id: user.user_id,
-    username: user.username,
     email: user.email,
   });
 

--- a/components/UserContext.tsx
+++ b/components/UserContext.tsx
@@ -17,7 +17,6 @@ export function UserProvider(props: {
   useEffect(() => {
     Sentry.setUser({
       id: props.user.user_id,
-      username: props.user.username,
       email: props.user.email,
     });
   }, [props.user]);

--- a/lib/auth/google/index.ts
+++ b/lib/auth/google/index.ts
@@ -91,7 +91,6 @@ export async function findOrCreateUserFromGoogleToken(rawToken: string) {
       first_name: claims.given_name!,
       last_name: claims.family_name!,
       email: claims.email!,
-      username: claims.email!.split("@")[0],
       avatar: claims.picture,
       identities: {
         create: {

--- a/lib/auth/slack/index.ts
+++ b/lib/auth/slack/index.ts
@@ -86,7 +86,6 @@ export async function findOrCreateUserFromSlackToken(userInfo: SlackTokenJson) {
       first_name: userInfo.given_name!,
       last_name: userInfo.family_name!,
       email: userInfo.email!,
-      username: userInfo.email!.split("@")[0],
       avatar: userInfo.picture!,
       identities: {
         create: {

--- a/lib/db/migrations/20240904143009_remove_username/migration.sql
+++ b/lib/db/migrations/20240904143009_remove_username/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `username` on the `users` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "users_username_key";
+
+-- AlterTable
+ALTER TABLE "users" DROP COLUMN "username";

--- a/lib/db/schema.prisma
+++ b/lib/db/schema.prisma
@@ -55,7 +55,6 @@ model Role {
 /// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
 model User {
   user_id                         Int          @id @default(autoincrement())
-  username                        String       @unique
   email                           String       @unique
   first_name                      String
   last_name                       String

--- a/lib/db/types/user.ts
+++ b/lib/db/types/user.ts
@@ -9,7 +9,6 @@ const jsonSchema: z.ZodSchema<Json> = z.lazy(() => z.union([literalSchema, z.arr
 
 export const _UserModel = z.object({
   user_id: z.number().int(),
-  username: z.string(),
   email: z.string(),
   first_name: z.string(),
   last_name: z.string(),


### PR DESCRIPTION
The user `username` field is unique, causing user creation to fail if the email prefix (anything before the "@") is used by another user. This made sense when only allowing google login from `@york.ac.uk` but causes issues now that login with slack is also available. The username field is unused everywhere except for Sentry, where it is used alongside the email it is derived from, and so is not needed.