### PR TITLE
Create certificates folder on SSL generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "NODE_ENV=production node dist/server/index.js",
     "lint": "next lint",
     "test": "lint-staged",
-    "ssl:generateCerts": "mkcert -install && mkcert -key-file certificates/key.pem -cert-file certificates/cert.pem localhost 127.0.0.1 ::1",
+    "ssl:generateCerts": "mkcert -install && mkdir certificates | true && mkcert -key-file certificates/key.pem -cert-file certificates/cert.pem localhost 127.0.0.1 ::1",
     "prisma:generate": "dotenv -c ${NODE_ENV:-development} -- prisma generate --schema ./lib/db/schema.prisma",
     "prisma:pull": "dotenv -c ${NODE_ENV:-development} -- prisma db pull --schema ./lib/db/schema.prisma",
     "prisma:migrateDev": "dotenv -c ${NODE_ENV:-development} -- prisma migrate dev --schema ./lib/db/schema.prisma",


### PR DESCRIPTION
Ensure that the `certificates` folder exists before attempting to write files to it.