### PR TITLE
Pass in Sentry auth token as Docker secret rather than build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM node:20-bookworm-slim AS base
 RUN apt-get update -y && apt-get install -y ca-certificates git openssl
 
 FROM base AS build
+RUN apt-get update -y && apt-get install -y build-essential python3
 WORKDIR /app
 COPY ./.yarn/ .yarn/
 COPY . /app/
@@ -12,11 +13,13 @@ RUN --mount=type=cache,id=calendar2023-yarn,target=.yarn/cache yarn install --im
 ENV NODE_ENV=production
 ARG GIT_REV
 ENV GIT_REV=$GIT_REV
-ARG SENTRY_AUTH_TOKEN
-ENV SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
 ARG VERSION
 ENV VERSION=$VERSION
-RUN SKIP_ENV_VALIDATION=1 PUBLIC_URL="http://localhost:3000" yarn run build
+RUN --mount=type=secret,id=sentry-auth-token \
+  SENTRY_AUTH_TOKEN=$(cat /run/secrets/sentry-auth-token) \
+  SKIP_ENV_VALIDATION=1 \
+  PUBLIC_URL="http://localhost:3000" \
+  yarn run build
 
 FROM base
 COPY --from=build /app/dist /app/dist

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
         sh """docker build \\
           --build-arg GIT_REV=${env.GIT_COMMIT} \\
           --build-arg VERSION=${env.TAG_NAME ?: 'v0.0.0'} \\
-          --build-arg SENTRY_AUTH_TOKEN=\$SENTRY_AUTH_TOKEN \\
+          --secret id=sentry-auth-token,env=SENTRY_AUTH_TOKEN \\
           -t registry.comp.ystv.co.uk/ystv/calendar2023:${imageTag}\\
           .
         """


### PR DESCRIPTION
Stop it from getting baked into the image (not ideal)