### PR TITLE
#CheckWithTech: Error handling and correct perms check

### DIFF
--- a/app/(authenticated)/calendar/[eventID]/CheckWithTech.tsx
+++ b/app/(authenticated)/calendar/[eventID]/CheckWithTech.tsx
@@ -97,13 +97,25 @@ function PostMessage(props: {
         loading={isPending}
         onClick={() =>
           startTransition(async () => {
-            await doCheckWithTech(props.eventID, memo, props.isConfident);
-            notifications.show({
-              title: "Sent!",
-              message:
-                "Keep an eye out on Slack in case the tech team need any further details.",
-            });
-            props.done();
+            const result = await doCheckWithTech(
+              props.eventID,
+              memo,
+              props.isConfident,
+            );
+            if (result.ok) {
+              notifications.show({
+                title: "Sent!",
+                message:
+                  "Keep an eye out on Slack in case the tech team need any further details.",
+              });
+              props.done();
+            } else {
+              notifications.show({
+                title: "Sorry, something went wrong...",
+                message: result.errors?.root ?? "Please try again later.",
+                color: "red",
+              });
+            }
           })
         }
         leftSection={<TbBrandSlack size={14} />}

--- a/app/(authenticated)/calendar/[eventID]/SignupSheet.tsx
+++ b/app/(authenticated)/calendar/[eventID]/SignupSheet.tsx
@@ -456,6 +456,7 @@ export function SignupSheetsView({
         !event.is_cancelled &&
         dayjs(event.start_date).isAfter(new Date()) &&
         (event.created_by === me.user_id ? (
+          // No need for this to be a canManageAnySignUpSheet, because there isn't one yet
           <Alert
             variant="light"
             color="blue"

--- a/app/(authenticated)/calendar/[eventID]/actions.ts
+++ b/app/(authenticated)/calendar/[eventID]/actions.ts
@@ -9,19 +9,11 @@ import { z } from "zod";
 import { AttendStatus, AttendStatuses } from "@/features/calendar/statuses";
 import * as Calendar from "@/features/calendar";
 import { EventType, hasRSVP } from "@/features/calendar/types";
-import {
-  canManage,
-  canManageSignUpSheet,
-} from "@/features/calendar/permissions";
+import { canManage } from "@/features/calendar/permissions";
 import { zodErrorResponse } from "@/components/FormServerHelpers";
-import {
-  EditEventSchema,
-  SignupSheetSchema,
-} from "@/app/(authenticated)/calendar/[eventID]/schema";
+import { EditEventSchema } from "@/app/(authenticated)/calendar/[eventID]/schema";
 import { FormResponse } from "@/components/Form";
-import { updateSignUpSheet } from "@/features/calendar/signup_sheets";
 import { updateEventAttendeeStatus } from "@/features/calendar/events";
-import { isBefore } from "date-fns";
 import invariant from "@/lib/invariant";
 import slackApiConnection, {
   isSlackEnabled,
@@ -308,7 +300,7 @@ export const doCheckWithTech = wrapServerAction(
     const event = await Calendar.getEvent(eventID);
     invariant(event, "Event does not exist");
 
-    if (!canManage(event, me)) {
+    if (!Calendar.canManageAnySignupSheet(event, me)) {
       return {
         ok: false,
         errors: {

--- a/app/(authenticated)/calendar/[eventID]/page.tsx
+++ b/app/(authenticated)/calendar/[eventID]/page.tsx
@@ -95,7 +95,7 @@ async function CheckWithTechPrompt({
   event: EventObjectType;
   me: UserType;
 }) {
-  if (me.user_id !== event.host) {
+  if (!canManageAnySignupSheet(event, me)) {
     return null;
   }
   if (event.adam_rms_project_id || event.check_with_tech_status) {


### PR DESCRIPTION
This fixes two issues with the #CheckWithTech form:

* The permissions check was using `canManage`, when it should have been `canManageAnySignUpSheet` (to allow any producer to submit it)
  * Also change the prompt display check to `canManageAnySignUpSheet`
* There was no error handling (oops)