### PR TITLE
Replace calls to getCurrentUser in page components with mustGetCurrentUser

### DIFF
--- a/app/(authenticated)/calendar/[eventID]/page.tsx
+++ b/app/(authenticated)/calendar/[eventID]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import invariant from "@/lib/invariant";
 import { getUserName } from "@/components/UserHelpers";
-import { getCurrentUser, UserType } from "@/lib/auth/server";
+import { mustGetCurrentUser, UserType } from "@/lib/auth/server";
 import { CurrentUserAttendeeRow } from "@/app/(authenticated)/calendar/[eventID]/AttendeeStatus";
 import { AttendStatusLabels } from "@/features/calendar/statuses";
 import { SignupSheetsView } from "@/app/(authenticated)/calendar/[eventID]/SignupSheet";
@@ -152,7 +152,7 @@ async function SlackBanner(props: { event: EventObjectType }) {
   if (!props.event.slack_channel_id) {
     return null;
   }
-  const me = await getCurrentUser();
+  const me = await mustGetCurrentUser();
   if (me.identities.find((x) => x.provider === "slack")) {
     return null;
   }
@@ -183,7 +183,7 @@ export default async function EventPage({
     notFound();
   }
 
-  const me = await getCurrentUser();
+  const me = await mustGetCurrentUser();
   let allMembers;
   if (canManage(event, me)) {
     allMembers = await getAllUsers();

--- a/app/(authenticated)/calendar/new/page.tsx
+++ b/app/(authenticated)/calendar/new/page.tsx
@@ -1,4 +1,4 @@
-import { getCurrentUser } from "@/lib/auth/server";
+import { mustGetCurrentUser } from "@/lib/auth/server";
 import { CreateEventForm } from "@/app/(authenticated)/calendar/new/form";
 import { creatableEventTypes } from "@/features/calendar/permissions";
 import { Forbidden } from "@/lib/auth/errors";
@@ -47,7 +47,7 @@ async function getSlackChannels(): Promise<Channel[]> {
 
 export default async function NewEventPage() {
   const permittedEventTypes = creatableEventTypes(
-    (await getCurrentUser()).permissions,
+    (await mustGetCurrentUser()).permissions,
   );
   if (permittedEventTypes.length === 0) {
     throw new Forbidden([

--- a/app/(authenticated)/calendar/page.tsx
+++ b/app/(authenticated)/calendar/page.tsx
@@ -4,7 +4,7 @@ import { PermissionGate } from "@/components/UserContext";
 import { listEvents, listVacantEvents } from "@/features/calendar/events";
 import { Alert, Button } from "@mantine/core";
 import { Permission } from "@/lib/auth/permissions";
-import { getCurrentUser } from "@/lib/auth/server";
+import { mustGetCurrentUser } from "@/lib/auth/server";
 import { TbArticle, TbCalendarEvent } from "react-icons/tb";
 import invariant from "@/lib/invariant";
 import { add, setDay } from "date-fns";
@@ -67,7 +67,7 @@ export default async function CalendarPage({
   const day = searchParams.day ? parseInt(searchParams.day, 10) : now.getDate();
   const selectedDay = new Date(year, month, day);
 
-  const me = await getCurrentUser();
+  const me = await mustGetCurrentUser();
 
   const filter = searchParams.filter;
 

--- a/app/(authenticated)/user/[id]/page.tsx
+++ b/app/(authenticated)/user/[id]/page.tsx
@@ -1,8 +1,4 @@
-import {
-  getCurrentUser,
-  mustGetCurrentUser,
-  requirePermission,
-} from "@/lib/auth/server";
+import { mustGetCurrentUser, requirePermission } from "@/lib/auth/server";
 import * as People from "@/features/people";
 import * as Calendar from "@/features/calendar";
 import { notFound } from "next/navigation";
@@ -31,7 +27,7 @@ import { SignoutButton } from "@/components/SignoutButton";
 export default async function UserPage({ params }: { params: { id: string } }) {
   let user: People.SecureUser;
   if (params.id === "me") {
-    user = People.SecureUserModel.parse(await getCurrentUser());
+    user = People.SecureUserModel.parse(await mustGetCurrentUser());
   } else {
     await requirePermission(
       "ManageMembers.Members.List",


### PR DESCRIPTION
Should stop sentry spam with `Not logged in` errors, instead returning a redirect to /login