### PR TITLE
Optimise clash checking by querying at the sheet level

### DIFF
--- a/app/(authenticated)/calendar/[eventID]/SignupSheet.tsx
+++ b/app/(authenticated)/calendar/[eventID]/SignupSheet.tsx
@@ -58,6 +58,7 @@ function SignupSheet({
   const [sheetState, setSheetState] = useState(sheet);
 
   const { socket, isConnected, transport } = useWebsocket();
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     async function onSheetUpdate(value: any) {
@@ -65,6 +66,9 @@ function SignupSheet({
 
       if (res) {
         setSheetState(res);
+        await queryClient.invalidateQueries({
+          queryKey: ["clashes", sheet.signup_id],
+        });
       }
     }
 

--- a/app/(authenticated)/calendar/[eventID]/SignupSheet.tsx
+++ b/app/(authenticated)/calendar/[eventID]/SignupSheet.tsx
@@ -43,7 +43,7 @@ import {
 } from "@/app/(authenticated)/calendar/[eventID]/signUpSheetActions";
 import { TbCalendarCheck } from "react-icons/tb";
 import dayjs from "dayjs";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useWebsocket } from "@/components/WebsocketProvider";
 
 function SignupSheet({
@@ -300,9 +300,10 @@ export function MyRoleSignUpModal({
   buttonless?: boolean;
 }) {
   const clashes = useQuery({
-    queryKey: ["clashes", crew.crew_id],
-    queryFn: () => checkRoleClashes(crew.crew_id),
+    queryKey: ["clashes", crew.signup_id],
+    queryFn: () => checkRoleClashes(crew.signup_id),
   });
+  const queryClient = useQueryClient();
 
   const [acceptClashes, setAcceptClashes] = useState<boolean>(false);
 
@@ -330,6 +331,9 @@ export function MyRoleSignUpModal({
                     setError(res.errors!.root as string);
                     return;
                   }
+                  queryClient.invalidateQueries({
+                    queryKey: ["clashes", crew.signup_id],
+                  });
                   onSuccess();
                 });
               }}
@@ -370,6 +374,9 @@ export function MyRoleSignUpModal({
                       setError(res.errors!.root as string);
                       return;
                     }
+                    queryClient.invalidateQueries({
+                      queryKey: ["clashes", crew.signup_id],
+                    });
                     onSuccess();
                   });
                 }}

--- a/app/(authenticated)/calendar/[eventID]/SignupSheet.tsx
+++ b/app/(authenticated)/calendar/[eventID]/SignupSheet.tsx
@@ -302,6 +302,7 @@ export function MyRoleSignUpModal({
   const clashes = useQuery({
     queryKey: ["clashes", crew.signup_id],
     queryFn: () => checkRoleClashes(crew.signup_id),
+    refetchOnMount: false,
   });
   const queryClient = useQueryClient();
 

--- a/app/(authenticated)/calendar/[eventID]/signUpSheetActions.ts
+++ b/app/(authenticated)/calendar/[eventID]/signUpSheetActions.ts
@@ -275,15 +275,10 @@ export const removeSelfFromRole = wrapServerAction(
 export const checkRoleClashes = wrapServerAction(
   "checkRoleClashes",
   async function checkRoleClashes(
-    crewID: number,
+    sheetID: number,
   ): Promise<Calendar.SignUpSheetWithEvent[]> {
     const me = await getCurrentUser();
-    const crewRole = await Calendar.getCrewRole(crewID);
-
-    if (!crewRole) return [];
-    const sheet = crewRole.signup_sheets;
-
-    const clashes = await Calendar.getClashingSheets(me, sheet);
+    const clashes = await Calendar.getClashingSheets(me, sheetID);
 
     return clashes;
   },

--- a/features/calendar/signup_sheets.ts
+++ b/features/calendar/signup_sheets.ts
@@ -10,6 +10,7 @@ import { UserType } from "@/lib/auth/server";
 export interface CrewType {
   crew_id: number;
   position_id: number;
+  signup_id: number;
   positions: CrewPositionType;
   ordering: number;
   locked: boolean;
@@ -296,7 +297,17 @@ export async function getCrewRole(crewID: number) {
   });
 }
 
-export async function getClashingSheets(user: UserType, sheet: SignupSheet) {
+export async function getClashingSheets(
+  user: UserType,
+  sheetOrID: SignupSheet | number,
+) {
+  let sheet;
+  if (typeof sheetOrID === "number") {
+    sheet = await getSignUpSheet(sheetOrID);
+  } else {
+    sheet = sheetOrID;
+  }
+  invariant(sheet, `Sheet ${sheetOrID} not found`);
   const clashingSheets = await prisma.signupSheet.findMany({
     where: {
       AND: [


### PR DESCRIPTION
Bit of a micro-optimisation: since by definition all crews on the same sheet have the same timings, either all of them have clashes or none of them do, so change the cache key to the sheet ID rather than the crew ID, and manually invalidate it upon signup/dropout.