### PR TITLE
Add alert on public events to distinguish them

### DIFF
--- a/app/(authenticated)/calendar/[eventID]/EventActionsUI.tsx
+++ b/app/(authenticated)/calendar/[eventID]/EventActionsUI.tsx
@@ -24,12 +24,13 @@ import {
 import { useCallback, useState, useTransition } from "react";
 import Image from "next/image";
 import AdamRMSLogo from "../../../_assets/adamrms-logo.png";
-import { Button, Menu, Modal, Select, Text } from "@mantine/core";
+import { Alert, Button, Menu, Modal, Select, Text } from "@mantine/core";
 import { useModals } from "@mantine/modals";
 import { useRouter } from "next/navigation";
 import { PermissionGate } from "@/components/UserContext";
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import type { Project } from "@/lib/adamrms";
+import { TbAlertTriangle } from "react-icons/tb";
 
 function EditModal(props: { event: EventObjectType; close: () => void }) {
   return (
@@ -57,6 +58,18 @@ function EditModal(props: { event: EventObjectType; close: () => void }) {
       {/*<CheckBoxField name="is_private" label="Private Event" />*/}
       <br />
       <CheckBoxField name="is_tentative" label="Tentative Event" />
+      {props.event.event_type === "public" && (
+        <Alert
+          variant="light"
+          color="orange"
+          icon={<TbAlertTriangle />}
+          title="Public Event"
+          className="mt-4"
+        >
+          This event is public. Its details can be seen by anyone outside YSTV{" "}
+          and any changes are immediately published.
+        </Alert>
+      )}
     </Form>
   );
 }

--- a/app/(authenticated)/calendar/[eventID]/page.tsx
+++ b/app/(authenticated)/calendar/[eventID]/page.tsx
@@ -215,6 +215,17 @@ export default async function EventPage({
           <SlackBanner event={event} />
         </Suspense>
       )}
+      {event.event_type === "public" && canManageAnySignupSheet(event, me) && (
+        <Alert
+          variant="light"
+          color="orange"
+          icon={<TbAlertTriangle />}
+          title="Public Event"
+        >
+          This event is public. Its details can be seen by anyone outside YSTV{" "}
+          and any changes are immediately published.
+        </Alert>
+      )}
       <div
         className={
           "flex w-full flex-col items-center justify-between sm:flex-row"

--- a/app/(authenticated)/calendar/new/form.tsx
+++ b/app/(authenticated)/calendar/new/form.tsx
@@ -14,10 +14,11 @@ import {
 import { useRouter } from "next/navigation";
 import { EventType } from "@/features/calendar/types";
 import { identity } from "lodash";
-import { InputLabel } from "@mantine/core";
+import { Alert, InputLabel } from "@mantine/core";
 import SlackChannelField from "@/components/SlackChannelField";
 import { useSlackEnabled } from "@/components/slack/SlackEnabledProvider";
 import { useCurrentUser } from "@/components/UserContext";
+import { TbAlertTriangle } from "react-icons/tb";
 
 export function CreateEventForm(props: {
   action: FormAction<{ id: number }>;
@@ -51,6 +52,14 @@ export function CreateEventForm(props: {
         childFieldName="host"
       >
         <SearchedMemberSelect name="host" label="Host" />
+      </ConditionalField>
+      <ConditionalField
+        referencedFieldName="type"
+        condition={(t) => t === "public"}
+      >
+        <Alert color="orange" icon={<TbAlertTriangle />} title="Public Event">
+          The details of this event will be visible to anyone outside YSTV.
+        </Alert>
       </ConditionalField>
       {/*<br />*/}
       {/*<CheckBoxField name="private" label="Private Event" />*/}

--- a/app/(authenticated)/calendar/new/form.tsx
+++ b/app/(authenticated)/calendar/new/form.tsx
@@ -57,7 +57,12 @@ export function CreateEventForm(props: {
         referencedFieldName="type"
         condition={(t) => t === "public"}
       >
-        <Alert color="orange" icon={<TbAlertTriangle />} title="Public Event">
+        <Alert
+          color="orange"
+          icon={<TbAlertTriangle />}
+          title="Public Event"
+          className="mt-1"
+        >
           The details of this event will be visible to anyone outside YSTV.
         </Alert>
       </ConditionalField>

--- a/components/FormFields.tsx
+++ b/components/FormFields.tsx
@@ -329,14 +329,14 @@ export function ConditionalField<
 >(props: {
   referencedFieldName: TField;
   condition: (data: TSchema[TField]) => boolean;
-  childFieldName: string;
+  childFieldName?: string;
   children: ReactNode;
 }) {
   const ctx = useFormContext<TSchema>();
   const referencedField = ctx.watch(props.referencedFieldName);
   const shouldShow = props.condition(referencedField);
   useEffect(() => {
-    if (!shouldShow) {
+    if (!shouldShow && props.childFieldName) {
       // @ts-expect-error - otherwise you get errors if referencedFieldName and childFieldName don't match
       ctx.setValue(props.childFieldName, undefined as any);
     }


### PR DESCRIPTION
Make it more obvious that any changes will be made public immediately to people outside YSTV.
<img width="776" alt="image" src="https://github.com/user-attachments/assets/3b7b2b01-3d64-4b1f-9e0c-a2bb5907149b">
<img width="1278" alt="image" src="https://github.com/user-attachments/assets/8196654f-e6a5-4231-a998-236a20e14618">
<img width="616" alt="image" src="https://github.com/user-attachments/assets/5f89d7b9-7517-41e8-a1df-4b0eb61ae09c">
