### PR TITLE
Remove public event banner on event page

### DIFF
--- a/app/(authenticated)/calendar/[eventID]/page.tsx
+++ b/app/(authenticated)/calendar/[eventID]/page.tsx
@@ -66,8 +66,8 @@ async function AttendeesView({
                 <td className={"text-sm"}>
                   {att.attend_status in AttendStatusLabels
                     ? AttendStatusLabels[
-                      att.attend_status as keyof typeof AttendStatusLabels
-                    ]
+                        att.attend_status as keyof typeof AttendStatusLabels
+                      ]
                     : AttendStatusLabels.unknown}
                 </td>
               </>

--- a/app/(authenticated)/calendar/[eventID]/page.tsx
+++ b/app/(authenticated)/calendar/[eventID]/page.tsx
@@ -66,7 +66,7 @@ async function AttendeesView({
                 <td className={"text-sm"}>
                   {att.attend_status in AttendStatusLabels
                     ? AttendStatusLabels[
-                    att.attend_status as keyof typeof AttendStatusLabels
+                      att.attend_status as keyof typeof AttendStatusLabels
                     ]
                     : AttendStatusLabels.unknown}
                 </td>

--- a/app/(authenticated)/calendar/[eventID]/page.tsx
+++ b/app/(authenticated)/calendar/[eventID]/page.tsx
@@ -66,8 +66,8 @@ async function AttendeesView({
                 <td className={"text-sm"}>
                   {att.attend_status in AttendStatusLabels
                     ? AttendStatusLabels[
-                        att.attend_status as keyof typeof AttendStatusLabels
-                      ]
+                    att.attend_status as keyof typeof AttendStatusLabels
+                    ]
                     : AttendStatusLabels.unknown}
                 </td>
               </>
@@ -214,17 +214,6 @@ export default async function EventPage({
         <Suspense fallback={null}>
           <SlackBanner event={event} />
         </Suspense>
-      )}
-      {event.event_type === "public" && canManageAnySignupSheet(event, me) && (
-        <Alert
-          variant="light"
-          color="orange"
-          icon={<TbAlertTriangle />}
-          title="Public Event"
-        >
-          This event is public. Its details can be seen by anyone outside YSTV{" "}
-          and any changes are immediately published.
-        </Alert>
       )}
       <div
         className={


### PR DESCRIPTION
It's not useful to see it there, and could be confusing. Keep it on the new/edit forms where it's relevant.