### PR TITLE
Make webcam loading spinners appear/disappear more reliably

### DIFF
--- a/components/WebcamView.tsx
+++ b/components/WebcamView.tsx
@@ -14,6 +14,8 @@ export function WebcamView(props: {
   const [videoReady, setVideoReady] = useState(false);
 
   useEffect(() => {
+    // Copy the element ref so that we can still reference it in the
+    // cleanup callback.
     const el = ref.current;
     if (!el) {
       return;
@@ -34,6 +36,8 @@ export function WebcamView(props: {
         el.removeEventListener(evt, isNotReady);
       }
     };
+    // Since the key of the video element is also webcamUrl, this effect
+    // will clean up and re-run whenever the webcamUrl changes.
   }, [props.webcamUrl]);
 
   return (

--- a/features/calendar/check_with_tech.ts
+++ b/features/calendar/check_with_tech.ts
@@ -1,4 +1,3 @@
-import { userHasPermission } from "@/lib/auth/core";
 import slackApiConnection from "@/lib/slack/slackApiConnection";
 import { getEvent } from "./events";
 import dayjs from "dayjs";
@@ -8,14 +7,10 @@ import { prisma } from "@/lib/db";
 import { env } from "@/lib/env";
 import {
   getCurrentUser,
-  hasPermission,
   mustGetCurrentUser,
   requirePermission,
 } from "@/lib/auth/server";
 import { ExposedUserModel } from "../people/users";
-import * as AdamRMS from "@/lib/adamrms";
-import { getUserName } from "@/components/UserHelpers";
-import { addProjectToAdamRMS } from "./adamRMS";
 import { _sendCWTFollowUpAndUpdateMessage } from "./check_with_tech_actions";
 import invariant from "@/lib/invariant";
 


### PR DESCRIPTION
The effect based approach was flawed in that React wouldn't re-run the effect if the `readystate` changed (even though it was in the list of dependencies, changes to stuff happening on refs doesn't trigger re-renders which therefore wouldn't trigger it to check for the effect dependency).

Replace it with an event-based approach.

(Also replaces `useDisclosure` with a `useState` to make the linter easier to appease.)