### PR TITLE
[INT-206] Rework post-login redirects

### DIFF
--- a/app/(authenticated)/calendar/[eventID]/CheckWithTech.tsx
+++ b/app/(authenticated)/calendar/[eventID]/CheckWithTech.tsx
@@ -164,7 +164,6 @@ function PostMessage(props: {
                         </Button>
                         <SlackLoginButton
                           mantineCompat
-                          slackClientID={result.slackClientID}
                           height="auto"
                           ml={"auto"}
                         />

--- a/app/(authenticated)/calendar/[eventID]/CheckWithTech.tsx
+++ b/app/(authenticated)/calendar/[eventID]/CheckWithTech.tsx
@@ -166,6 +166,7 @@ function PostMessage(props: {
                           mantineCompat
                           height="auto"
                           ml={"auto"}
+                          redirect={`/calendar/${props.eventID}`}
                         />
                       </Group>
                     </>

--- a/app/(authenticated)/calendar/[eventID]/page.tsx
+++ b/app/(authenticated)/calendar/[eventID]/page.tsx
@@ -214,8 +214,8 @@ async function SlackBanner(props: { event: EventObjectType }) {
         Connect your Slack account to join it automatically.
         <Group>
           <SlackLoginButton
-            slackClientID={process.env.SLACK_CLIENT_ID!}
             mantineCompat
+            redirect={`/calendar/${props.event.event_id}`}
           />
         </Group>
       </Stack>

--- a/app/(authenticated)/user/me/page.tsx
+++ b/app/(authenticated)/user/me/page.tsx
@@ -82,10 +82,7 @@ export default async function UserPage() {
               <h2 className="mt-0">Link your account to Slack</h2>
               <Suspense>
                 <Group>
-                  <SlackLoginButton
-                    slackClientID={process.env.SLACK_CLIENT_ID!}
-                    mantineCompat
-                  />
+                  <SlackLoginButton mantineCompat redirect="/user/me" />
                 </Group>
               </Suspense>
             </Card>

--- a/app/login/google/callback/route.ts
+++ b/app/login/google/callback/route.ts
@@ -1,4 +1,4 @@
-import { loginOrCreateUserGoogle } from "@/lib/auth/server";
+import { cookieName, loginOrCreateUserGoogle } from "@/lib/auth/server";
 import { env } from "@/lib/env";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -6,7 +6,7 @@ export const dynamic = "force-dynamic";
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const cookies = req.cookies;
-  const redirect = cookies.get("ystv-calendar-session.redirect");
+  const redirect = cookies.get(`${cookieName}.redirect`);
 
   const dataRaw = await req.formData();
   const idToken = dataRaw.get("credential");

--- a/app/login/google/route.ts
+++ b/app/login/google/route.ts
@@ -1,0 +1,33 @@
+import { cookieName } from "@/lib/auth/server";
+import { env } from "@/lib/env";
+import { randomUUID } from "crypto";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const redirect = req.nextUrl.searchParams.get("redirect");
+
+  const googleLoginURI = `https://accounts.google.com/gsi/select?client_id=${
+    env.GOOGLE_CLIENT_ID
+  }&ux_mode=redirect&login_uri=${encodeURIComponent(
+    env.PUBLIC_URL! + "/login/google/callback",
+  )}&ui_mode=card&context=signin${
+    env.GOOGLE_PERMITTED_DOMAINS
+      ? `&hosted_domain=${env.GOOGLE_PERMITTED_DOMAINS}`
+      : ""
+  }&g_csrf_token=${randomUUID()}&origin=${encodeURIComponent(env.PUBLIC_URL!)}`;
+
+  const res = NextResponse.redirect(googleLoginURI);
+
+  if (redirect !== null) {
+    res.cookies.set(`${cookieName}.redirect`, redirect, {
+      domain: env.COOKIE_DOMAIN,
+    });
+  } else {
+    res.cookies.set(`${cookieName}.redirect`, "", {
+      domain: env.COOKIE_DOMAIN,
+      maxAge: 0,
+    });
+  }
+
+  return res;
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -39,14 +39,8 @@ export default async function GoogleSignInPage(props: {
         </Center>
         <Center>
           <Stack>
-            <GoogleLoginButton
-              clientID={env.GOOGLE_CLIENT_ID!}
-              hostedDomain={env.GOOGLE_PERMITTED_DOMAINS}
-              gCsrfCookie={crypto.randomUUID()}
-            />
-            {isSlackEnabled && (
-              <SlackLoginButton slackClientID={process.env.SLACK_CLIENT_ID!} />
-            )}
+            <GoogleLoginButton />
+            {isSlackEnabled && <SlackLoginButton />}
           </Stack>
         </Center>
       </div>

--- a/app/login/slack/route.ts
+++ b/app/login/slack/route.ts
@@ -1,0 +1,28 @@
+import { cookieName } from "@/lib/auth/server";
+import { env } from "@/lib/env";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const redirect = req.nextUrl.searchParams.get("redirect");
+
+  const slackLoginURI = `https://slack.com/openid/connect/authorize?scope=openid&response_type=code&client_id=${
+    env.SLACK_CLIENT_ID
+  }&redirect_uri=${encodeURIComponent(
+    env.PUBLIC_URL + "/login/slack/callback",
+  )}&scope=openid profile email`;
+
+  const res = NextResponse.redirect(slackLoginURI);
+
+  if (redirect !== null) {
+    res.cookies.set(`${cookieName}.redirect`, redirect, {
+      domain: env.COOKIE_DOMAIN,
+    });
+  } else {
+    res.cookies.set(`${cookieName}.redirect`, "", {
+      domain: env.COOKIE_DOMAIN,
+      maxAge: 0,
+    });
+  }
+
+  return res;
+}

--- a/components/SignoutButton/actions.ts
+++ b/components/SignoutButton/actions.ts
@@ -1,11 +1,12 @@
 "use server";
 
 import { wrapServerAction } from "@/lib/actions";
+import { cookieName } from "@/lib/auth/server";
 import { env } from "@/lib/env";
 import { cookies } from "next/headers";
 
 export const signOut = wrapServerAction("signOut", async function signOut() {
-  cookies().set("ystv-calendar-session", "", {
+  cookies().set(cookieName, "", {
     maxAge: 0,
     domain: env.COOKIE_DOMAIN,
   });

--- a/components/google/GoogleLoginButton.tsx
+++ b/components/google/GoogleLoginButton.tsx
@@ -1,31 +1,24 @@
 "use client";
 
 import { usePublicURL } from "@/components/PublicURLContext";
-import { useSearchParams, useRouter } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import Script from "next/script";
-import { setRedirectCookie } from "./actions";
 import { Button } from "@mantine/core";
+import Link from "next/link";
 
-export function GoogleLoginButton(props: {
-  clientID: string;
-  hostedDomain: string | undefined;
-  redirect?: string;
-  gCsrfCookie: string;
-}) {
+export function GoogleLoginButton(props: { redirect?: string }) {
   const publicURL = usePublicURL();
   const searchParams = useSearchParams();
 
-  const router = useRouter();
-
   const loginRedirect = searchParams.get("redirect");
 
-  const googleLoginURL = `https://accounts.google.com/gsi/select?client_id=${
-    props.clientID
-  }&ux_mode=redirect&login_uri=${encodeURIComponent(
-    publicURL + "/login/google/callback",
-  )}&ui_mode=card&context=signin${
-    props.hostedDomain ? `&hosted_domain=${props.hostedDomain}` : ""
-  }&g_csrf_token=${props.gCsrfCookie}&origin=${encodeURIComponent(publicURL)}`;
+  const googleLoginURL = `${publicURL}/login/google${
+    props.redirect
+      ? "?redirect=" + props.redirect
+      : loginRedirect !== null
+      ? "?redirect=" + loginRedirect
+      : ""
+  }`;
 
   return (
     <>
@@ -47,10 +40,8 @@ export function GoogleLoginButton(props: {
           textDecoration: "none",
           width: 256,
         }}
-        onClick={async () => {
-          await setRedirectCookie(loginRedirect ?? "");
-          router.push(googleLoginURL);
-        }}
+        component={Link}
+        href={`${googleLoginURL}`}
       >
         <GoogleIcon />
         Sign in with Google

--- a/components/google/actions.ts
+++ b/components/google/actions.ts
@@ -1,13 +1,14 @@
 "use server";
 
 import { wrapServerAction } from "@/lib/actions";
+import { cookieName } from "@/lib/auth/server";
 import { env } from "@/lib/env";
 import { cookies } from "next/headers";
 
 export const setRedirectCookie = wrapServerAction(
   "setRedirectCookie",
   async function setRedirectCookie(redirect: string) {
-    cookies().set("ystv-calendar-session.redirect", redirect, {
+    cookies().set(`${cookieName}.redirect`, redirect, {
       domain: env.COOKIE_DOMAIN,
     });
   },

--- a/components/slack/SlackLoginButton.tsx
+++ b/components/slack/SlackLoginButton.tsx
@@ -4,31 +4,35 @@ import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { usePublicURL } from "../PublicURLContext";
 import SlackIcon from "../icons/SlackIcon";
-import { Button, MantineStyleProps } from "@mantine/core";
+import { Button, ButtonProps, MantineStyleProps } from "@mantine/core";
+import { PolymorphicComponentProps } from "@mantine/core/lib/core/factory/create-polymorphic-component";
 
 export default function SlackLoginButton(props: {
-  slackClientID: string;
   height?: number | string;
   mantineCompat?: boolean;
+  redirect?: string;
   ml?: MantineStyleProps["ml"];
+  variant?: PolymorphicComponentProps<"button", ButtonProps>["variant"];
 }) {
   const publicURL = usePublicURL();
   const searchParams = useSearchParams();
 
   const loginRedirect = searchParams.get("redirect");
 
-  const slackLoginLink = `https://slack.com/openid/connect/authorize?scope=openid&response_type=code&client_id=${
-    props.slackClientID
-  }&redirect_uri=${encodeURIComponent(
-    publicURL + "/login/slack/callback",
-  )}&scope=openid profile email`;
+  const slackLoginLink = `${publicURL}/login/slack${
+    props.redirect
+      ? "?redirect=" + props.redirect
+      : loginRedirect !== null
+      ? "?redirect=" + loginRedirect
+      : ""
+  }`;
 
   return (
     <>
       {props.mantineCompat ? (
         <Button
           leftSection={<SlackIcon />}
-          variant="light"
+          variant={props.variant || "light"}
           color="gray"
           component={Link}
           href={slackLoginLink}

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -26,7 +26,7 @@ export async function requirePermission(...perms: Permission[]) {
   if (!(await hasPermission(...perms))) throw new Forbidden(perms);
 }
 
-const cookieName = "ystv-calendar-session";
+export const cookieName = "ystv-calendar-session";
 
 const sessionSchema = z.object({
   userID: z.number(),

--- a/lib/auth/slack/index.ts
+++ b/lib/auth/slack/index.ts
@@ -25,16 +25,14 @@ export type SlackTokenJson = {
   picture: string;
 };
 
-export async function getSlackUserInfo(code: string, redirect?: string | null) {
+export async function getSlackUserInfo(code: string) {
   invariant(isSlackEnabled, "Slack is not enabled");
   const slackApp = await slackApiConnection();
   const tokenResponse = await slackApp.client.openid.connect.token({
     client_id: env.SLACK_CLIENT_ID || "",
     client_secret: env.SLACK_CLIENT_SECRET || "",
     code: code,
-    redirect_uri: `${env.PUBLIC_URL}/login/slack/callback${
-      redirect ? "?redirect=" + redirect : ""
-    }`,
+    redirect_uri: `${env.PUBLIC_URL}/login/slack/callback`,
   });
   const token = jwtDecode(tokenResponse.id_token!) as SlackTokenJson;
   return token;

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { TSocket } from ".";
 import { ExtendedError } from "socket.io/dist/namespace";
 import { env } from "../lib/env";
+import { cookieName } from "@/lib/auth/server";
 
 export async function authenticateSocket(
   socket: TSocket,
@@ -31,7 +32,7 @@ export async function authenticateSocket(
 
   const cookie = parseCookie(socket.client.request.headers.cookie);
 
-  const sessionCookie: string | undefined = cookie["ystv-calendar-session"];
+  const sessionCookie: string | undefined = cookie[cookieName];
 
   if (sessionCookie) {
     var decodedSession: unknown;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,7 +31,8 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    "lib/db/seed.mts"
+    "lib/db/seed.mts",
+    "lib/db/**/*.d.ts"
   ],
   "exclude": ["node_modules", "dist", ".next", "out", "next.config.js"],
   "ts-node": {

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -8,5 +8,5 @@
     "noEmit": false,
     "jsx": "react-jsx"
   },
-  "include": ["server/**/*.ts"]
+  "include": ["server/**/*.ts", "lib/db/json.d.ts"]
 }


### PR DESCRIPTION
Use the `/login/[provider]` endpoint to:
- Set a cookie for the redirect value
- Redirect to the regular login uri for the provider

This cookie is then read by the `/login/[provider]callback` route and redirects the user correctly after successful authentication