### PR TITLE
[INT-133] Word breaks for long words in event titles

### DIFF
--- a/app/(authenticated)/calendar/[eventID]/page.tsx
+++ b/app/(authenticated)/calendar/[eventID]/page.tsx
@@ -271,7 +271,7 @@ export default async function EventPage({
           "flex w-full flex-col items-center justify-between sm:flex-row"
         }
       >
-        <div className="w-fit grow font-bold">
+        <div className="w-fit grow break-words font-bold">
           <h1
             className={twMerge(
               "text-4xl font-bold",


### PR DESCRIPTION
Tested with the same event title in the ticket description and it looks like the really long word with no spaces was an edge case causing the title cutoff. 

![Screenshot 2024-10-20 181743](https://github.com/user-attachments/assets/12c0df35-aeb8-4651-b895-149a95afc347)
