### PR TITLE
[INT-209] Update CheckWithTech Slack message even if requestor doesn't have Slack linked

### DIFF
--- a/features/calendar/check_with_tech_actions.ts
+++ b/features/calendar/check_with_tech_actions.ts
@@ -501,7 +501,7 @@ export async function _sendCWTFollowUpAndUpdateMessage(
           elements: [
             {
               type: "plain_text",
-              text: newContext!,
+              text: newContext,
               emoji: true,
             },
           ],

--- a/features/calendar/check_with_tech_actions.ts
+++ b/features/calendar/check_with_tech_actions.ts
@@ -404,13 +404,15 @@ export async function handleSlackViewEvent(data: SlackViewMiddlewareArgs) {
   if (!newStatus) {
     return;
   }
-  await _sendCWTFollowUpAndUpdateMessage(
-    cwt,
-    actor,
-    newStatus,
-    notes ?? "",
-    request,
-  );
+  if (reqType !== "Note") {
+    await _sendCWTFollowUpAndUpdateMessage(
+      cwt,
+      actor,
+      newStatus,
+      notes ?? "",
+      request,
+    );
+  }
 }
 
 export interface FullCheckWithTech extends CheckWithTech {

--- a/features/calendar/check_with_tech_actions.ts
+++ b/features/calendar/check_with_tech_actions.ts
@@ -460,6 +460,10 @@ export async function _sendCWTFollowUpAndUpdateMessage(
     case "Rejected":
       newContext = `:x: Declined by ${getUserName(actor)}`;
       break;
+    case "Requested":
+      invariant(false, "CWTFollowUp: Expected status other than Requested");
+    default:
+      invariant(false, "CWTFollowUp: Unknown status " + newStatus);
   }
 
   const lines = [


### PR DESCRIPTION
This pull request includes updates to the `handleSlackViewEvent` and `_sendCWTFollowUpAndUpdateMessage` functions in the `features/calendar/check_with_tech_actions.ts` file to improve error handling and message updating logic.

Error handling improvements:

* Added a try-catch block around the Slack message update to log errors and ensure the requestor still receives a DM even if the update fails. [[1]](diffhunk://#diff-ba8b1057447e994f200a7de3ac31ace439de039b0dbf795e20ea3a7cefe9fdabR488) [[2]](diffhunk://#diff-ba8b1057447e994f200a7de3ac31ace439de039b0dbf795e20ea3a7cefe9fdabL515-R536)

Message updating logic enhancements:

* Moved the logic for finding the requestor's Slack identity and sending a DM to the requestor to after the channel message update. [[1]](diffhunk://#diff-ba8b1057447e994f200a7de3ac31ace439de039b0dbf795e20ea3a7cefe9fdabL451-R456) [[2]](diffhunk://#diff-ba8b1057447e994f200a7de3ac31ace439de039b0dbf795e20ea3a7cefe9fdabL515-R536)
* Added new status checks for "Requested" and unknown statuses to ensure proper handling and logging of unexpected statuses.

Other small changes:

* Added a check for `reqType` not being "Note" before sending a follow-up message.
* Cleaned up the function by closing it properly.