### PR TITLE
[INT-215] Add past events list to profile, and allow admins to view other users' profiles

### DIFF
--- a/app/(authenticated)/admin/positions/PositionView.tsx
+++ b/app/(authenticated)/admin/positions/PositionView.tsx
@@ -25,7 +25,6 @@ import {
 import { useDisclosure } from "@mantine/hooks";
 import { SearchBar } from "@/components/SearchBar";
 import { CreatePositionForm, UpdatePositionForm } from "./form";
-import { useValidSearchParams } from "@/lib/searchParams/validate";
 import { getSearchParamsString } from "@/lib/searchParams/util";
 import { PositionCard } from "./PositionCard";
 import {
@@ -36,6 +35,7 @@ import {
   updatePositionAction,
 } from "./actions";
 import { useQuery } from "@tanstack/react-query";
+import { useValidSearchParams } from "@/lib/searchParams/validateHook";
 
 export function PositionView(props: { initialPositions: TFetchPositions }) {
   const pathname = usePathname();

--- a/app/(authenticated)/admin/roles/RoleView.tsx
+++ b/app/(authenticated)/admin/roles/RoleView.tsx
@@ -22,7 +22,6 @@ import {
 } from "@/components/Pagination";
 import { useDisclosure } from "@mantine/hooks";
 import { SearchBar } from "@/components/SearchBar";
-import { useValidSearchParams } from "@/lib/searchParams/validate";
 import { getSearchParamsString } from "@/lib/searchParams/util";
 import { RoleCard } from "./RoleCard";
 import { CreateRoleForm, UpdateRoleForm } from "./form";
@@ -36,6 +35,7 @@ import {
   updateRoleAction,
 } from "./actions";
 import { useQuery } from "@tanstack/react-query";
+import { useValidSearchParams } from "@/lib/searchParams/validateHook";
 
 export function RoleView(props: { initialRoles: TFetchRoles }) {
   const pathname = usePathname();

--- a/app/(authenticated)/admin/users/UserView.tsx
+++ b/app/(authenticated)/admin/users/UserView.tsx
@@ -19,7 +19,7 @@ import {
   PaginationProvider,
 } from "@/components/Pagination";
 import { SearchBar } from "@/components/SearchBar";
-import { useValidSearchParams } from "@/lib/searchParams/validate";
+import { useValidSearchParams } from "@/lib/searchParams/validateHook";
 import { getSearchParamsString } from "@/lib/searchParams/util";
 import { UserCard } from "./UserCard";
 import { useQuery } from "@tanstack/react-query";

--- a/app/(authenticated)/user/[id]/page.tsx
+++ b/app/(authenticated)/user/[id]/page.tsx
@@ -1,0 +1,11 @@
+import { requirePermission } from "@/lib/auth/server";
+import { UserPage } from "../me/page";
+
+export default async function ArbitraryUserPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  await requirePermission("Admin.Users");
+  return <UserPage id={parseInt(params.id, 10)} />;
+}

--- a/app/(authenticated)/user/[id]/page.tsx
+++ b/app/(authenticated)/user/[id]/page.tsx
@@ -6,6 +6,6 @@ export default async function ArbitraryUserPage({
 }: {
   params: { id: string };
 }) {
-  await requirePermission("Admin.Users");
+  await requirePermission("People.ViewProfile.All");
   return <UserPage id={parseInt(params.id, 10)} />;
 }

--- a/app/(authenticated)/user/me/page.tsx
+++ b/app/(authenticated)/user/me/page.tsx
@@ -176,6 +176,7 @@ async function MyEvents({ userID }: { userID: number }) {
           <TableTr>
             <TableTh>Event</TableTh>
             <TableTh>Date</TableTh>
+            <TableTh>Role</TableTh>
           </TableTr>
         </TableThead>
         <TableTbody>
@@ -186,6 +187,12 @@ async function MyEvents({ userID }: { userID: number }) {
               </TableTd>
               <TableTd>
                 <DateTime val={event.start_date.toUTCString()} format="date" />
+              </TableTd>
+              <TableTd>
+                {event.signup_sheets
+                  // getAllEventsForUser pre-filters this to only include our crews
+                  .flatMap((sheet) => sheet.crews.map((c) => c.positions.name))
+                  .join(", ")}
               </TableTd>
             </TableTr>
           ))}

--- a/app/(authenticated)/user/me/page.tsx
+++ b/app/(authenticated)/user/me/page.tsx
@@ -1,8 +1,21 @@
-import { mustGetCurrentUser, requirePermission } from "@/lib/auth/server";
+import { getCurrentUser, mustGetCurrentUser } from "@/lib/auth/server";
 import * as People from "@/features/people";
 import * as Calendar from "@/features/calendar";
 import { getUserName } from "@/components/UserHelpers";
-import { Avatar, Card, Group, Skeleton, Space, Stack } from "@mantine/core";
+import {
+  Avatar,
+  Card,
+  Group,
+  Skeleton,
+  Space,
+  Stack,
+  Table,
+  TableTbody,
+  TableTd,
+  TableTh,
+  TableThead,
+  TableTr,
+} from "@mantine/core";
 import { UserPreferences } from "./UserPreferences";
 import { ICalCopyButton } from "@/components/ICalCopyButton";
 import SlackLoginButton from "@/components/slack/SlackLoginButton";
@@ -14,14 +27,26 @@ import Link from "next/link";
 import { env } from "@/lib/env";
 import { SignoutButton } from "@/components/SignoutButton";
 import { PageInfo } from "@/components/PageInfo";
+import { notFound } from "next/navigation";
+import invariant from "@/lib/invariant";
+import { DateTime } from "@/components/DateTimeHelpers";
 
-export default async function UserPage() {
-  const user = People.SecureUserModel.parse(await mustGetCurrentUser());
+export default async function MePage() {
+  return <UserPage id={(await mustGetCurrentUser()).user_id} />;
+}
+
+export async function UserPage(props: { id: number }) {
+  const user = await People.getUserSecure(props.id);
+  if (!user) {
+    notFound();
+  }
+  const me = await getCurrentUser();
+  const isMe = me.user_id === props.id;
   const prefs = People.preferenceDefaults(user.preferences);
   const slackUser = user.identities.find((i) => i.provider === "slack");
   return (
     <div>
-      <PageInfo title="My Profile" />
+      <PageInfo title={isMe ? "My Profile" : getUserName(user)} />
       <Card withBorder>
         <Group>
           {user.avatar && (
@@ -35,16 +60,18 @@ export default async function UserPage() {
               {user.email}
             </h4>
           </Stack>
-          <SignoutButton />
+          {isMe && <SignoutButton />}
         </Group>
       </Card>
       <Space h={"md"} />
-      <Card withBorder>
-        <Stack gap={0}>
-          <h2 className="mt-0">Preferences</h2>
-          <UserPreferences value={prefs} />
-        </Stack>
-      </Card>
+      {isMe && (
+        <Card withBorder>
+          <Stack gap={0}>
+            <h2 className="mt-0">Preferences</h2>
+            <UserPreferences value={prefs} />
+          </Stack>
+        </Card>
+      )}
       <Space h={"md"} />
       <Card withBorder>
         <Group>
@@ -69,13 +96,15 @@ export default async function UserPage() {
         </Group>
       </Card>
       <Space h={"md"} />
-      <Card withBorder>
-        <Suspense fallback={<Skeleton height={38} animate />}>
-          <Wrapped />
-        </Suspense>
-      </Card>
+      <Suspense fallback={<Skeleton height={38} animate />}>
+        <Wrapped userID={user.user_id} />
+      </Suspense>
       <Space h={"md"} />
-      {isSlackEnabled && (
+      <Suspense fallback={<Skeleton height={38} animate />}>
+        <MyEvents userID={user.user_id} />
+      </Suspense>
+      <Space h={"md"} />
+      {isSlackEnabled && isMe && (
         <>
           {!slackUser ? (
             <Card withBorder>
@@ -110,23 +139,58 @@ export default async function UserPage() {
   );
 }
 
-async function Wrapped() {
-  const me = await mustGetCurrentUser();
+async function Wrapped({ userID }: { userID: number }) {
+  const me = await People.getUserSecure(userID);
+  invariant(me, "no user");
   const has2024 = await hasWrapped(me.email, 2024);
   if (!has2024) {
     return null;
   }
   return (
-    <Group>
-      <div>
-        <h2 className="mt-0">YSTV Wrapped</h2>
-        <p className="my-1">Watch back previous years&apos; YSTV Wrapped.</p>
-        <ul>
-          <li>
-            <Link href="/wrapped?year=2024">YSTV Wrapped 2024</Link>
-          </li>
-        </ul>
-      </div>
-    </Group>
+    <Card withBorder>
+      <Group>
+        <div>
+          <h2 className="mt-0">YSTV Wrapped</h2>
+          <p className="my-1">Watch back previous years&apos; YSTV Wrapped.</p>
+          <ul>
+            <li>
+              <Link href="/wrapped?year=2024">YSTV Wrapped 2024</Link>
+            </li>
+          </ul>
+        </div>
+      </Group>
+    </Card>
+  );
+}
+
+async function MyEvents({ userID }: { userID: number }) {
+  const events = await Calendar.getAllEventsForUser(userID);
+  if (events.length === 0) {
+    return null;
+  }
+  return (
+    <Card withBorder>
+      <h2>My Events</h2>
+      <Table>
+        <TableThead>
+          <TableTr>
+            <TableTh>Event</TableTh>
+            <TableTh>Date</TableTh>
+          </TableTr>
+        </TableThead>
+        <TableTbody>
+          {events.map((event) => (
+            <TableTr key={event.event_id}>
+              <TableTd>
+                <Link href={`/calendar/${event.event_id}`}>{event.name}</Link>
+              </TableTd>
+              <TableTd>
+                <DateTime val={event.start_date.toUTCString()} format="date" />
+              </TableTd>
+            </TableTr>
+          ))}
+        </TableTbody>
+      </Table>
+    </Card>
   );
 }

--- a/app/(authenticated)/user/me/page.tsx
+++ b/app/(authenticated)/user/me/page.tsx
@@ -100,10 +100,6 @@ export async function UserPage(props: { id: number }) {
         <Wrapped userID={user.user_id} />
       </Suspense>
       <Space h={"md"} />
-      <Suspense fallback={<Skeleton height={38} animate />}>
-        <MyEvents userID={user.user_id} />
-      </Suspense>
-      <Space h={"md"} />
       {isSlackEnabled && isMe && (
         <>
           {!slackUser ? (
@@ -135,6 +131,10 @@ export async function UserPage(props: { id: number }) {
           )}
         </>
       )}
+      <Space h={"md"} />
+      <Suspense fallback={<Skeleton height={38} animate />}>
+        <MyEvents userID={user.user_id} />
+      </Suspense>
     </div>
   );
 }

--- a/features/calendar/events.ts
+++ b/features/calendar/events.ts
@@ -502,3 +502,34 @@ export async function deleteEvent(eventID: number, userID: number) {
     },
   });
 }
+
+export async function getAllEventsForUser(userID: number) {
+  const events = await prisma.event.findMany({
+    where: {
+      OR: [
+        {
+          signup_sheets: {
+            some: {
+              crews: {
+                some: {
+                  user_id: userID,
+                },
+              },
+            },
+          },
+        },
+        {
+          attendees: {
+            some: {
+              user_id: userID,
+            },
+          },
+        },
+      ],
+    },
+    orderBy: {
+      start_date: "asc",
+    },
+  });
+  return events;
+}

--- a/features/calendar/events.ts
+++ b/features/calendar/events.ts
@@ -530,6 +530,20 @@ export async function getAllEventsForUser(userID: number) {
     orderBy: {
       start_date: "asc",
     },
+    include: {
+      signup_sheets: {
+        include: {
+          crews: {
+            include: {
+              positions: true,
+            },
+            where: {
+              user_id: userID,
+            },
+          },
+        },
+      },
+    },
   });
   return events;
 }

--- a/features/people/users.ts
+++ b/features/people/users.ts
@@ -64,6 +64,17 @@ export async function getUser(id: number): Promise<ExposedUser | null> {
   return ExposedUserModel.parse(user);
 }
 
+export async function getUserSecure(id: number): Promise<SecureUser | null> {
+  const user = await prisma.user.findUnique({
+    where: { user_id: id },
+    include: {
+      identities: true,
+    },
+  });
+  if (!user) return null;
+  return SecureUserModel.parse(user);
+}
+
 export async function setUserPreference<
   K extends keyof PrismaJson.UserPreferences,
 >(userID: number, key: K, value: PrismaJson.UserPreferences[K]) {

--- a/lib/auth/permissions.ts
+++ b/lib/auth/permissions.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
  * Available permissions. Should contain all the ones that users are expected
  * to have, along with some special ones:
  * * MEMBER - any logged in user
- * * PUBLIC - open to the world with no authentication
+ * * PUBLIC - open to the world with no authentication (not implemented)
  * * SuperUser - can do anything (don't use this unless you know what you're doing)
  */
 export const PermissionEnum = z.enum([
@@ -27,6 +27,7 @@ export const PermissionEnum = z.enum([
   "CheckWithTech.Submit",
   "CheckWithTech.Admin",
   "ManageQuotes",
+  "People.ViewProfile.All",
   "Admin.Users",
   "Admin.Roles",
   "Admin.Positions",

--- a/lib/searchParams/validate.ts
+++ b/lib/searchParams/validate.ts
@@ -1,7 +1,6 @@
 import {
   ReadonlyURLSearchParams,
   redirect,
-  usePathname,
   useSearchParams,
 } from "next/navigation";
 import { z } from "zod";
@@ -60,36 +59,6 @@ export function validateSearchParams<Schema extends z.AnyZodObject>(
 
     return data.data;
   }
-}
-
-/**
- * A fun little function for validating URL search params against a zod schema,
- *    if running on the client will redirect to keep params in the same order as they
- *    appear in the schema
- * @param schema A zod schema to validate the searchParams against, must contain all
- *    optional or values with defaults
- * @param searchParams Search params either from client (URLSearchParams type) or
- *    server (Object)
- * @param data data.server must be set if running on the server, otherwise shit breaks
- * @returns Validated search params as an object
- */
-export function useValidSearchParams<Schema extends z.AnyZodObject>(
-  schema: Schema,
-  searchParams: ReadonlyURLSearchParams | Object,
-): z.infer<Schema> {
-  "use client";
-  const validSearchParams = validateSearchParams(schema, searchParams);
-
-  const pathname = usePathname();
-  const oldSearchParams = Object.fromEntries(useSearchParams().entries());
-  const oldSearchParamsString = getSearchParamsString(oldSearchParams);
-  const newSearchParamsString = getSearchParamsString(validSearchParams);
-
-  if (newSearchParamsString !== oldSearchParamsString) {
-    redirect(`${pathname}?${newSearchParamsString}`);
-  }
-
-  return validSearchParams;
 }
 
 function getValue<T, K extends keyof T>(data: T, key: K) {

--- a/lib/searchParams/validateHook.ts
+++ b/lib/searchParams/validateHook.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import {
+  ReadonlyURLSearchParams,
+  usePathname,
+  useSearchParams,
+  redirect,
+} from "next/navigation";
+import { z } from "zod";
+import { getSearchParamsString } from "./util";
+import { validateSearchParams } from "./validate";
+
+/**
+ * A fun little function for validating URL search params against a zod schema,
+ *    if running on the client will redirect to keep params in the same order as they
+ *    appear in the schema
+ * @param schema A zod schema to validate the searchParams against, must contain all
+ *    optional or values with defaults
+ * @param searchParams Search params either from client (URLSearchParams type) or
+ *    server (Object)
+ * @param data data.server must be set if running on the server, otherwise shit breaks
+ * @returns Validated search params as an object
+ */
+export function useValidSearchParams<Schema extends z.AnyZodObject>(
+  schema: Schema,
+  searchParams: ReadonlyURLSearchParams | Object,
+): z.infer<Schema> {
+  const validSearchParams = validateSearchParams(schema, searchParams);
+
+  const pathname = usePathname();
+  const oldSearchParams = Object.fromEntries(useSearchParams().entries());
+  const oldSearchParamsString = getSearchParamsString(oldSearchParams);
+  const newSearchParamsString = getSearchParamsString(validSearchParams);
+
+  if (newSearchParamsString !== oldSearchParamsString) {
+    redirect(`${pathname}?${newSearchParamsString}`);
+  }
+
+  return validSearchParams;
+}


### PR DESCRIPTION
https://linear.app/ystv/issue/INT-215

## What

* Adds a section to the user profile page to show a list of past events
* Allows admins to go to any user's profile page (with some current-user-specific things stubbed out)

## Why

Nice to reminisce on your productions. Also sometimes useful to see what someone's been involved in (e.g. award submissions).

## How

Adds a `/user/[id]` route that renders the same page as `/user/me`, but for a given id, behind the new `People.ViewProfile.All` permission. On the user page, hides some bits unless the user is the current user.

Then, adds a listing of past events to a section on the page, behind a suspense boundary.

Also in the process I ran into issues with Next complaining that `lib/searchParams/validate.ts` was importing `usePathname` in non-client components, so I split that out into a client-only `validateHook` file.

## Testing

<img width="1227" alt="image" src="https://github.com/user-attachments/assets/68180a8b-cca0-48bb-8567-d6f59d85ba87" />
And accessing it for another user:
<img width="1187" alt="image" src="https://github.com/user-attachments/assets/291992a1-7af1-4a36-889f-943f051f33c0" />

