### PR TITLE
Fix controller.field.value being possibly undefined

### DIFF
--- a/components/FormFields.tsx
+++ b/components/FormFields.tsx
@@ -483,7 +483,7 @@ export function PermissionSelectField(props: {
               .filter(
                 (v) =>
                   v.toLowerCase().includes(filter.toLowerCase()) ||
-                  (controller.field.value as Permission[]).includes(v),
+                  ((controller.field.value || []) as Permission[]).includes(v),
               )
               .map((key) => (
                 <Chip key={key} value={key} variant="outline">


### PR DESCRIPTION
Noticed that attempting to filter permissions when creating a role while no permissions were slected would cause an error. Stopped it doing that.