### PR TITLE
[Nix Flake] Do not set prisma env vars on darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,12 +4,19 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = import nixpkgs {
           inherit system;
         };
+        isDarwin = pkgs.stdenv.isDarwin;
       in
       {
         devShells.default = pkgs.mkShell {
@@ -19,9 +26,11 @@
             mkcert
           ];
 
-          PRISMA_QUERY_ENGINE_LIBRARY = "${pkgs.prisma-engines}/lib/libquery_engine.node";
-          PRISMA_QUERY_ENGINE_BINARY = "${pkgs.prisma-engines}/bin/query-engine";
-          PRISMA_SCHEMA_ENGINE_BINARY = "${pkgs.prisma-engines}/bin/schema-engine";
+          env = pkgs.lib.optionalAttrs (!isDarwin) {
+            PRISMA_QUERY_ENGINE_LIBRARY = "${pkgs.prisma-engines}/lib/libquery_engine.node";
+            PRISMA_QUERY_ENGINE_BINARY = "${pkgs.prisma-engines}/bin/query-engine";
+            PRISMA_SCHEMA_ENGINE_BINARY = "${pkgs.prisma-engines}/bin/schema-engine";
+          };
         };
       }
     );


### PR DESCRIPTION
## What

Don't set the prisma env variables on darwin in nix shells

## Why

It wasn't working before

## How

If is darwin, don't set

## Testing

It works now
