### PR TITLE
[INT-218] Add slack team_id to the login url

### DIFF
--- a/app/login/slack/route.ts
+++ b/app/login/slack/route.ts
@@ -10,7 +10,9 @@ export async function GET(req: NextRequest) {
     env.SLACK_CLIENT_ID
   }&redirect_uri=${encodeURIComponent(
     env.PUBLIC_URL + "/login/slack/callback",
-  )}&scope=openid profile email`;
+  )}&scope=openid profile email${
+    env.SLACK_TEAM_ID ? "&team=" + env.SLACK_TEAM_ID : ""
+  }`;
 
   const res = NextResponse.redirect(slackLoginURI);
 


### PR DESCRIPTION
https://linear.app/ystv/issue/INT-218

## What

Add slack team_id to the login url users are redirected to.

## Why

To hopefully stop users getting prompted to enter a workspace URL when linking their accounts.

## How

I looked up how to on google.

## Testing

Going to be honest, that's happening in dev.
