### PR TITLE
[INT-218] Skip slack workspace selection screen on login

### DIFF
--- a/app/login/slack/route.ts
+++ b/app/login/slack/route.ts
@@ -6,13 +6,13 @@ import { env } from "@/lib/env";
 export async function GET(req: NextRequest) {
   const redirect = req.nextUrl.searchParams.get("redirect");
 
-  const slackLoginURI = `https://slack.com/openid/connect/authorize?scope=openid&response_type=code&client_id=${
+  const slackLoginURI = `https://${
+    env.SLACK_TEAM_URL_PREFIX ? env.SLACK_TEAM_URL_PREFIX + "." : ""
+  }slack.com/openid/connect/authorize?scope=openid&response_type=code&client_id=${
     env.SLACK_CLIENT_ID
   }&redirect_uri=${encodeURIComponent(
     env.PUBLIC_URL + "/login/slack/callback",
-  )}&scope=openid profile email${
-    env.SLACK_TEAM_ID ? "&team=" + env.SLACK_TEAM_ID : ""
-  }`;
+  )}&scope=openid profile email`;
 
   const res = NextResponse.redirect(slackLoginURI);
 

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -46,7 +46,7 @@ const envSchema = z.object({
   SLACK_SIGNING_SECRET: slackEnvType,
   SLACK_CLIENT_ID: slackEnvType,
   SLACK_CLIENT_SECRET: slackEnvType,
-  SLACK_TEAM_ID: z.string().optional(),
+  SLACK_TEAM_URL_PREFIX: z.string().optional(),
   SLACK_CHECK_WITH_TECH_CHANNEL: slackEnvType,
   SLACK_USER_FEEDBACK_CHANNEL: slackEnvType.default("#dev-internal-site"),
   SLACK_DISABLE_SOCKET_MODE: z.enum(["true", "false"]).default("false"), // Used to disable socket mode in dev since it shares an app with prod

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -46,6 +46,7 @@ const envSchema = z.object({
   SLACK_SIGNING_SECRET: slackEnvType,
   SLACK_CLIENT_ID: slackEnvType,
   SLACK_CLIENT_SECRET: slackEnvType,
+  SLACK_TEAM_ID: z.string().optional(),
   SLACK_TEAM_URL_PREFIX: z.string().optional(),
   SLACK_CHECK_WITH_TECH_CHANNEL: slackEnvType,
   SLACK_USER_FEEDBACK_CHANNEL: slackEnvType.default("#dev-internal-site"),


### PR DESCRIPTION
https://linear.app/ystv/issue/INT-218 <!-- fill this in, or remove if there isn't one -->

## What

Skips the workspace selection screen when signing in with slack

## Why

I did it wrong the last time

## How

Change to a URL prefix instead of team_id in params

## Testing

Replicating the URL in dev with its client ID works and skips workspace selection.
