### PR TITLE
[INT-227] Websocket message sends fail in production

### DIFF
--- a/lib/socket/server/signUpSheet.ts
+++ b/lib/socket/server/signUpSheet.ts
@@ -1,7 +1,9 @@
 import "server-only";
 
-import { io } from ".";
+import { type Server } from "socket.io";
 
 export async function socketUpdateSignupSheet(signupSheetID: number) {
-  io.in("authenticatedUsers").emit(`signupSheetUpdate:${signupSheetID}`);
+  (globalThis as unknown as { io: Server }).io
+    .in("authenticatedUsers")
+    .emit(`signupSheetUpdate:${signupSheetID}`);
 }


### PR DESCRIPTION
https://linear.app/ystv/issue/INT-227 <!-- fill this in, or remove if there isn't one -->

## What

Skip io import and access globalThis directly to allow signup updates to be sent

## Why

Linear reported the server failing to read properties when accessing io from an import

## How

Access the io property of globalThis directly

## Testing

Tested in PR preview, updates to crew sheets work as expected
