### PR TITLE
[INT-228] Use existing user session when creating slack link

### DIFF
--- a/app/login/slack/callback/route.ts
+++ b/app/login/slack/callback/route.ts
@@ -27,8 +27,8 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   }
 
   const slackUserInfo = await getSlackUserInfo(code);
-  let _user = await getCurrentUserOrNull(req);
-  _user = await loginOrCreateUserSlack(slackUserInfo);
+  const user = await getCurrentUserOrNull(req);
+  await loginOrCreateUserSlack(slackUserInfo, user);
 
   var url = new URL(redirect?.value ?? "/user/me", env.PUBLIC_URL!);
 

--- a/lib/auth/slack/index.ts
+++ b/lib/auth/slack/index.ts
@@ -37,10 +37,16 @@ export async function getSlackUserInfo(code: string) {
   return token;
 }
 
-export async function findOrCreateUserFromSlackToken(userInfo: SlackTokenJson) {
+export async function findOrCreateUserFromSlackToken(
+  userInfo: SlackTokenJson,
+  existingUserID: number | undefined,
+) {
   const user = await prisma.user.findFirst({
     where: {
       OR: [
+        {
+          user_id: existingUserID,
+        },
         {
           identities: {
             some: {


### PR DESCRIPTION
https://linear.app/ystv/issue/INT-228 <!-- fill this in, or remove if there isn't one -->

## What

Use existing user session when creating slack link

## Why

Linking your slack account which uses a different email to internal-site login creates a whole new account in internal-site even if you're already logged in.

## How

Pull in existing user session and use that when looking up user.

## Testing

Going to happen in dev.
