### PR TITLE
Updated patch for Full Calendar DayGrid to keep the custom styling for mobile views

### DIFF
--- a/.yarn/patches/@fullcalendar-daygrid-npm-6.1.19-7693fff707.patch
+++ b/.yarn/patches/@fullcalendar-daygrid-npm-6.1.19-7693fff707.patch
@@ -1,0 +1,63 @@
+diff --git a/internal.js b/internal.js
+index e505d7fa88602503c859a1f3f6f66b17b03e82d1..96f40be8cb195d733526cc01cf7e81cc7d83862d 100644
+--- a/internal.js
++++ b/internal.js
+@@ -221,7 +221,6 @@ class TableCell extends DateComponent {
+                 'fc-daygrid-day',
+                 ...(props.extraClassNames || []),
+             ], elAttrs: Object.assign(Object.assign(Object.assign({}, props.extraDataAttrs), (props.showDayNumber ? { 'aria-labelledby': state.dayNumberId } : {})), { role: 'gridcell' }), defaultGenerator: renderTopInner, date: date, dateProfile: dateProfile, todayRange: props.todayRange, showDayNumber: props.showDayNumber, isMonthStart: isMonthStart, extraRenderProps: props.extraRenderProps }, (InnerContent, renderProps) => (createElement("div", { ref: props.innerElRef, className: "fc-daygrid-day-frame fc-scrollgrid-sync-inner", style: { minHeight: props.minHeight } },
+-            props.showWeekNumber && (createElement(WeekNumberContainer, { elTag: "a", elClasses: ['fc-daygrid-week-number'], elAttrs: buildNavLinkAttrs(context, date, 'week'), date: date, defaultFormat: DEFAULT_WEEK_NUM_FORMAT })),
+             !renderProps.isDisabled &&
+                 (props.showDayNumber || hasCustomDayCellContent(options) || props.forceDayTop) ? (createElement("div", { className: "fc-daygrid-day-top" },
+                 createElement(InnerContent, { elTag: "a", elClasses: [
+@@ -531,20 +530,36 @@ class TableRow extends DateComponent {
+          (props.eventDrag && props.eventDrag.affectedInstances) ||
+             (props.eventResize && props.eventResize.affectedInstances) ||
+             {};
+-        return (createElement("tr", { ref: this.rootElRef, role: "row" },
+-            props.renderIntro && props.renderIntro(),
+-            props.cells.map((cell, col) => {
+-                let normalFgNodes = this.renderFgSegs(col, props.forPrint ? singleColPlacements[col] : multiColPlacements[col], props.todayRange, isForcedInvisible);
+-                let mirrorFgNodes = this.renderFgSegs(col, buildMirrorPlacements(mirrorSegsByCol[col], multiColPlacements), props.todayRange, {}, Boolean(props.eventDrag), Boolean(props.eventResize), false);
+-                return (createElement(TableCell, { key: cell.key, elRef: this.cellElRefs.createRef(cell.key), innerElRef: this.frameElRefs.createRef(cell.key) /* FF <td> problem, but okay to use for left/right. TODO: rename prop */, dateProfile: props.dateProfile, date: cell.date, showDayNumber: props.showDayNumbers, showWeekNumber: props.showWeekNumbers && col === 0, forceDayTop: props.showWeekNumbers /* even displaying weeknum for row, not necessarily day */, todayRange: props.todayRange, eventSelection: props.eventSelection, eventDrag: props.eventDrag, eventResize: props.eventResize, extraRenderProps: cell.extraRenderProps, extraDataAttrs: cell.extraDataAttrs, extraClassNames: cell.extraClassNames, extraDateSpan: cell.extraDateSpan, moreCnt: moreCnts[col], moreMarginTop: moreMarginTops[col], singlePlacements: singleColPlacements[col], fgContentElRef: this.fgElRefs.createRef(cell.key), fgContent: ( // Fragment scopes the keys
+-                    createElement(Fragment, null,
+-                        createElement(Fragment, null, normalFgNodes),
+-                        createElement(Fragment, null, mirrorFgNodes))), bgContent: ( // Fragment scopes the keys
+-                    createElement(Fragment, null,
+-                        this.renderFillSegs(highlightSegsByCol[col], 'highlight'),
+-                        this.renderFillSegs(businessHoursByCol[col], 'non-business'),
+-                        this.renderFillSegs(bgEventSegsByCol[col], 'bg-event'))), minHeight: props.cellMinHeight }));
+-            })));
++        /////////
++        // debugger;
++        let { dateEnv } = context
++        let date  = props.cells[0].date
++        let format = options.weekNumberFormat || props.defaultFormat
++        let num = dateEnv.computeWeekNumber(date) // TODO: somehow use for formatting as well?
++        let text = dateEnv.format(date, format)
++        let renderProps = { num, text, date }
++        /////////
++        return [createElement(options.dayHeaders ? "tr" : "div", { ref: this.rootElRef, role: options.dayHeaders ? "row" : "rowgroup", style: options.dayHeaders ? undefined : { display: "contents", fontSize: "110%" }},
++            (props.showWeekNumbers ? [createElement("td", {elClasses: ['fc-daygrid-day'], role: "gridcell", style: {fontWeight: 700, backgroundColor: !options.dayHeaders && "var(--fc-neutral-bg-color)", verticalAlign: options.dayHeaders && "middle", rotate: options.dayHeaders && "180deg", width: options.dayHeaders && "1.6em"}}, createElement("div", {style: {writingMode: options.dayHeaders && "vertical-rl", margin: options.dayHeaders ? ".6rem .1rem" : ".6rem", height: options.dayHeaders && "max-content"}}, options.weekNumberContent(renderProps)))] : []).concat(
++                props.cells.map((cell, col) => {
++                    let normalFgNodes = this.renderFgSegs(col, props.forPrint ? singleColPlacements[col] : options.dayHeaders ? multiColPlacements[col] : singleColPlacements[col], props.todayRange, isForcedInvisible);
++                    let mirrorFgNodes = this.renderFgSegs(col, buildMirrorPlacements(mirrorSegsByCol[col], multiColPlacements), props.todayRange, {}, Boolean(props.eventDrag), Boolean(props.eventResize), false);
++                    return (createElement(TableCell, { key: cell.key, elRef: this.cellElRefs.createRef(cell.key), innerElRef: this.frameElRefs.createRef(cell.key) /* FF <td> problem, but okay to use for left/right. TODO: rename prop */, dateProfile: props.dateProfile, date: cell.date, showDayNumber: props.showDayNumbers, showWeekNumber: props.showWeekNumbers && col === 0, forceDayTop: props.showWeekNumbers /* even displaying weeknum for row, not necessarily day */, todayRange: props.todayRange, eventSelection: props.eventSelection, eventDrag: props.eventDrag, eventResize: props.eventResize, extraRenderProps: cell.extraRenderProps, extraDataAttrs: cell.extraDataAttrs, extraClassNames: cell.extraClassNames, extraDateSpan: cell.extraDateSpan, moreCnt: moreCnts[col], moreMarginTop: moreMarginTops[col], singlePlacements: singleColPlacements[col], fgContentElRef: this.fgElRefs.createRef(cell.key), fgContent: ( // Fragment scopes the keys
++                            createElement(Fragment, null,
++                                createElement(Fragment, null, normalFgNodes),
++                                createElement(Fragment, null, mirrorFgNodes))), bgContent: ( // Fragment scopes the keys
++                            createElement(Fragment, null,
++                                this.renderFillSegs(highlightSegsByCol[col], 'highlight'),
++                                this.renderFillSegs(businessHoursByCol[col], 'non-business'),
++                                this.renderFillSegs(bgEventSegsByCol[col], 'bg-event'))), minHeight: props.cellMinHeight }));
++                })).reduce(function (rows, key, index, array) {
++                return options.dayHeaders ? array:
++                    (index % 1 == 0 ? rows.push([key])
++                        : rows[rows.length-1].push(key)) && rows;
++            }, []).map((row, index) => {
++                return options.dayHeaders ? row : createElement("tr", { key: index, role: "row" }, row);
++            })
++        ), !options.dayHeaders && createElement("div", {elClasses: ["fc-daygrid-ystv-spacer"]})];
+     }
+     componentDidMount() {
+         this.updateSizing(true);

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fullcalendar/core": "^6.1.19",
-    "@fullcalendar/daygrid": "^6.1.19",
+    "@fullcalendar/daygrid": "patch:@fullcalendar/daygrid@npm%3A6.1.19#~/.yarn/patches/@fullcalendar-daygrid-npm-6.1.19-7693fff707.patch",
     "@fullcalendar/list": "^6.1.19",
     "@fullcalendar/react": "^6.1.19",
     "@fullcalendar/timegrid": "^6.1.19",
@@ -139,7 +139,8 @@
   "packageManager": "yarn@4.9.2",
   "resolutions": {
     "@fullcalendar/daygrid@^6.1.8": "patch:@fullcalendar/daygrid@npm%3A6.1.8#./.yarn/patches/@fullcalendar-daygrid-npm-6.1.8-3f45184389.patch",
-    "@fullcalendar/daygrid@~6.1.8": "patch:@fullcalendar/daygrid@npm%3A6.1.8#./.yarn/patches/@fullcalendar-daygrid-npm-6.1.8-3f45184389.patch"
+    "@fullcalendar/daygrid@~6.1.8": "patch:@fullcalendar/daygrid@npm%3A6.1.8#./.yarn/patches/@fullcalendar-daygrid-npm-6.1.8-3f45184389.patch",
+    "@fullcalendar/daygrid@npm:~6.1.19": "patch:@fullcalendar/daygrid@npm%3A6.1.19#~/.yarn/patches/@fullcalendar-daygrid-npm-6.1.19-7693fff707.patch"
   },
   "lint-staged": {
     "*": "prettier --ignore-unknown --write"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2599,12 +2599,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fullcalendar/daygrid@npm:^6.1.19, @fullcalendar/daygrid@npm:~6.1.19":
+"@fullcalendar/daygrid@npm:6.1.19":
   version: 6.1.19
   resolution: "@fullcalendar/daygrid@npm:6.1.19"
   peerDependencies:
     "@fullcalendar/core": ~6.1.19
   checksum: 10/1d1f15685e53fe73713ed523a497d9d5c8660d20e08c50a0c4bf040902144c9e571f536932a6b5c9ccc60c00fe2127879963bf05fbda736eaced439ddc06a1b3
+  languageName: node
+  linkType: hard
+
+"@fullcalendar/daygrid@patch:@fullcalendar/daygrid@npm%3A6.1.19#~/.yarn/patches/@fullcalendar-daygrid-npm-6.1.19-7693fff707.patch":
+  version: 6.1.19
+  resolution: "@fullcalendar/daygrid@patch:@fullcalendar/daygrid@npm%3A6.1.19#~/.yarn/patches/@fullcalendar-daygrid-npm-6.1.19-7693fff707.patch::version=6.1.19&hash=8cf366"
+  peerDependencies:
+    "@fullcalendar/core": ~6.1.19
+  checksum: 10/d936f65b3f0828be9c7d194b68a63379cc95bc6796dbad71d7020f1a5a12a27cda6c5fe4f4ad50898d9bd7889d7a75f86e6cdd61160d194e8be36ae8589ac3d4
   languageName: node
   linkType: hard
 
@@ -12778,7 +12787,7 @@ __metadata:
   resolution: "hypothetical-new-internal-site@workspace:."
   dependencies:
     "@fullcalendar/core": "npm:^6.1.19"
-    "@fullcalendar/daygrid": "npm:^6.1.19"
+    "@fullcalendar/daygrid": "patch:@fullcalendar/daygrid@npm%3A6.1.19#~/.yarn/patches/@fullcalendar-daygrid-npm-6.1.19-7693fff707.patch"
     "@fullcalendar/list": "npm:^6.1.19"
     "@fullcalendar/react": "npm:^6.1.19"
     "@fullcalendar/timegrid": "npm:^6.1.19"


### PR DESCRIPTION
## What

Updates patch for Full Calendar DayGrid to keep the custom styling for mobile views

## Why

Calendar is more visually consistent than pure list view since it doesn't jump dates etc

## How

Same questionable method as before, may need improving sometime but in fairness this is the first time it's been changed since release so maybe not needed?

## Testing

Haven't.
