### PR TITLE
[INT-234] Fix timestamps in link unfurls

### DIFF
--- a/lib/slack/actions.ts
+++ b/lib/slack/actions.ts
@@ -118,11 +118,15 @@ async function getUnfurl({
             fields: [
               {
                 type: "mrkdwn",
-                text: `*Start Time*: ${dayjs(event.start_date).format(
+                text: `*Start Time*: <!date^${dayjs(
+                  event.start_date,
+                ).unix()}^{time} {date}|${dayjs(event.start_date).format(
                   "HH:mm dddd Do MMM",
-                )}\n*End Time*: ${dayjs(event.end_date).format(
+                )}>\n*End Time*: <!date^${dayjs(
+                  event.end_date,
+                ).unix()}^{time} {date}|${dayjs(event.end_date).format(
                   "HH:mm dddd Do MMM",
-                )}`,
+                )}>`,
               },
             ],
           },


### PR DESCRIPTION
https://linear.app/ystv/issue/INT-XXX <!-- fill this in, or remove if there isn't one -->

## What

Fix timestamps in link unfurls

## Why

They wrong

## How

Using Slack's questionable timestamp formatting

## Testing

Works locally
