### PR TITLE
[INT-236] Only return 'Event not found' when the link is to an event

### DIFF
--- a/lib/slack/actions.ts
+++ b/lib/slack/actions.ts
@@ -57,7 +57,7 @@ async function getUnfurl({
 }: {
   url: string;
   domain: string;
-}): Promise<MessageAttachment> {
+}): Promise<MessageAttachment | undefined> {
   const trailingPath = url.substring(
     url.indexOf(domain) + domain.length,
     url.length,
@@ -133,17 +133,17 @@ async function getUnfurl({
         ],
       };
     }
-  }
 
-  return {
-    blocks: [
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: "Event not found",
+    return {
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: "Event not found",
+          },
         },
-      },
-    ],
-  };
+      ],
+    };
+  }
 }


### PR DESCRIPTION
https://linear.app/ystv/issue/INT-XXX <!-- fill this in, or remove if there isn't one -->

## What

Only unfurl links in slack when the link is to an event

## Why

Marks said 'pls fix'

## How

Moved the return statement for the event not found unfurl

## Testing

Meh
