### PR TITLE
Make Prounouns available to public api route

### DIFF
--- a/features/committee/teams.ts
+++ b/features/committee/teams.ts
@@ -104,6 +104,7 @@ export const fetchPublicCommittee = wrapServerAction(
                         first_name: true,
                         last_name: true,
                         public_avatar: true,
+                        pronouns: true,
                       },
                     },
                   },


### PR DESCRIPTION
## What
^^

## Why
Shows it on welcome-site (after some other PR there)

## How
Added a db access

## Testing
<img width="676" height="698" alt="image" src="https://github.com/user-attachments/assets/a06af130-7cc5-4115-b62e-59a64eba6de0" />

Very little change
